### PR TITLE
[Phase 1.1] Set unique document.title on all routes

### DIFF
--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+const usePageTitle = (title: string): void => {
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+};
+
+export default usePageTitle;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from 'react';
+import usePageTitle from '../hooks/usePageTitle';
 import '../styles/PageContent.css';
 import '../styles/About.css';
 
 const About = () => {
-    useEffect(() => { document.title = 'About | PRODBYRIQ'; }, []);
+    usePageTitle('About | PRODBYRIQ');
     return (
         <div className="page-content">
             <div className="about-hero">

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from 'react';
 import '../styles/PageContent.css';
 import '../styles/About.css';
 
 const About = () => {
+    useEffect(() => { document.title = 'About | PRODBYRIQ'; }, []);
     return (
         <div className="page-content">
             <div className="about-hero">

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import CalendarSync from '../components/CalendarSync';
+import usePageTitle from '../hooks/usePageTitle';
 
 const Admin: React.FC = () => {
+  usePageTitle('Admin Dashboard | PRODBYRIQ');
   return (
     <div className="admin-page min-h-screen bg-gray-100 py-8">
       <div className="container mx-auto px-4">

--- a/src/pages/Beats.tsx
+++ b/src/pages/Beats.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import usePageTitle from '../hooks/usePageTitle';
 import '../styles/PageContent.css';
 import '../styles/BeatsStyles.css';
 import BeatCard from '../components/beats/BeatCard';
@@ -13,7 +14,7 @@ const Beats: React.FC = () => {
   const [currentlyPlaying, setCurrentlyPlaying] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => { document.title = 'Buy Beats | PRODBYRIQ'; }, []);
+  usePageTitle('Buy Beats | PRODBYRIQ');
 
   // Load beats data
   useEffect(() => {

--- a/src/pages/Beats.tsx
+++ b/src/pages/Beats.tsx
@@ -13,6 +13,8 @@ const Beats: React.FC = () => {
   const [currentlyPlaying, setCurrentlyPlaying] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  useEffect(() => { document.title = 'Buy Beats | PRODBYRIQ'; }, []);
+
   // Load beats data
   useEffect(() => {
     setBeats(beatsData.beats);

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import StudioBookingForm from '../components/StudioBookingForm';
 import '../styles/PageContent.css';
 import '../styles/Booking.css';
 
 const Booking: React.FC = () => {
+    useEffect(() => { document.title = 'Book a Studio Session | PRODBYRIQ'; }, []);
     return <StudioBookingForm />;
 };
 

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react';
+import React from 'react';
+import usePageTitle from '../hooks/usePageTitle';
 import StudioBookingForm from '../components/StudioBookingForm';
 import '../styles/PageContent.css';
 import '../styles/Booking.css';
 
 const Booking: React.FC = () => {
-    useEffect(() => { document.title = 'Book a Studio Session | PRODBYRIQ'; }, []);
+    usePageTitle('Book a Studio Session | PRODBYRIQ');
     return <StudioBookingForm />;
 };
 

--- a/src/pages/FeaturedWork.tsx
+++ b/src/pages/FeaturedWork.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import '../styles/PageContent.css';
 import '../styles/FeaturedWork.css';
@@ -13,6 +13,7 @@ interface Track {
 }
 
 const FeaturedWork = () => {
+    useEffect(() => { document.title = 'Featured Work | PRODBYRIQ'; }, []);
     const [filter, setFilter] = useState<'all' | 'spotify' | 'soundcloud'>('all');
 
     // Sample tracks - you can easily add more here

--- a/src/pages/FeaturedWork.tsx
+++ b/src/pages/FeaturedWork.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import usePageTitle from '../hooks/usePageTitle';
 import { Link } from 'react-router-dom';
 import '../styles/PageContent.css';
 import '../styles/FeaturedWork.css';
@@ -13,7 +14,7 @@ interface Track {
 }
 
 const FeaturedWork = () => {
-    useEffect(() => { document.title = 'Featured Work | PRODBYRIQ'; }, []);
+    usePageTitle('Featured Work | PRODBYRIQ');
     const [filter, setFilter] = useState<'all' | 'spotify' | 'soundcloud'>('all');
 
     // Sample tracks - you can easily add more here

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,12 @@
-import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import SpotifyTrack from '../components/SpotifyTrack';
+import usePageTitle from '../hooks/usePageTitle';
 import '../styles/PageContent.css';
 import '../styles/Home.css';
 
 
 const Home = () => {
-    useEffect(() => { document.title = 'PRODBYRIQ | Beats, Mixing & Music Production'; }, []);
+    usePageTitle('PRODBYRIQ | Beats, Mixing & Music Production');
     const featuredTracks = [
         {
             url: 'https://open.spotify.com/track/3rlbQrNDUyIpF5QPjpFCkV',

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import SpotifyTrack from '../components/SpotifyTrack';
 import '../styles/PageContent.css';
@@ -5,6 +6,7 @@ import '../styles/Home.css';
 
 
 const Home = () => {
+    useEffect(() => { document.title = 'PRODBYRIQ | Beats, Mixing & Music Production'; }, []);
     const featuredTracks = [
         {
             url: 'https://open.spotify.com/track/3rlbQrNDUyIpF5QPjpFCkV',

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import usePageTitle from '../hooks/usePageTitle';
 import '../styles/PageContent.css';
 import '../styles/ServicesStyles.css';
 import { useCart } from '../components/cart/CartProvider';
@@ -11,7 +12,7 @@ const Services: React.FC = () => {
   const [expandedCard, setExpandedCard] = useState<string | null>(null);
   const { addServiceToCart } = useCart();
 
-  useEffect(() => { document.title = 'Mixing & Mastering Services | PRODBYRIQ'; }, []);
+  usePageTitle('Mixing & Mastering Services | PRODBYRIQ');
 
   useEffect(() => {
     setServices(servicesData.services as Service[]);

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -11,6 +11,8 @@ const Services: React.FC = () => {
   const [expandedCard, setExpandedCard] = useState<string | null>(null);
   const { addServiceToCart } = useCart();
 
+  useEffect(() => { document.title = 'Mixing & Mastering Services | PRODBYRIQ'; }, []);
+
   useEffect(() => {
     setServices(servicesData.services as Service[]);
     setIsLoading(false);

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import usePageTitle from '../hooks/usePageTitle';
 import { useLocation, Link } from 'react-router-dom';
 import '../styles/PageContent.css';
 import '../styles/Success.css';
@@ -12,7 +13,7 @@ const Success = () => {
     const [error, setError] = useState<string | null>(null);
     const location = useLocation();
 
-    useEffect(() => { document.title = 'Order Confirmed | PRODBYRIQ'; }, []);
+    usePageTitle('Order Confirmed | PRODBYRIQ');
 
     useEffect(() => {
         const processSuccessfulPayment = async () => {

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -12,6 +12,8 @@ const Success = () => {
     const [error, setError] = useState<string | null>(null);
     const location = useLocation();
 
+    useEffect(() => { document.title = 'Order Confirmed | PRODBYRIQ'; }, []);
+
     useEffect(() => {
         const processSuccessfulPayment = async () => {
             try {


### PR DESCRIPTION
Each page component now sets a descriptive browser tab title via useEffect on mount. Fixes all routes showing the default "Vite + React + TS" scaffold title.