### PR TITLE
[Phase 1.4 + 1.5] Fix hero CTA routing + footer copyright year

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -71,7 +71,7 @@ const Footer: React.FC = () => {
       </div>
       
       <div className="footer-bottom">
-        <p>&copy; 2025 ProdByRiq LLC. All rights reserved.</p>
+        <p>&copy; {new Date().getFullYear()} ProdByRiq LLC. All rights reserved.</p>
       </div>
     </footer>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -33,7 +33,7 @@ const Home = () => {
                         From beat creation to final mastering, I deliver industry-standard quality that makes your music stand out.
                     </p>
                     <div className="hero-buttons">
-                        <Link to="/booking" className="cta-button primary">Book a Session</Link>
+                        <Link to="/services" className="cta-button primary">Book a Session</Link>
                         <Link to="/about" className="cta-button secondary">Learn More</Link>
                     </div>
                 </div>


### PR DESCRIPTION
## Changes

### P1.4 — Homepage CTA routing
- `src/pages/Home.tsx`: Primary hero button "Book a Session" now routes to `/services` instead of `/booking`
- The previous routing sent visitors to the external studio booking form, bypassing the mixing & mastering services page entirely — a direct conversion loss

### P1.5 — Footer copyright year
- `src/components/Footer.tsx`: Replaced hardcoded `2025` with `{new Date().getFullYear()}`
- Auto-updates every year, no manual fix needed

Build passes ✓ TypeScript strict passes ✓