### PR TITLE
[Phase C] Redesign Homepage

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -79,21 +79,21 @@ const Home = () => {
                     </div>
                     <div className="services-cards">
                         <Link to="/beats" className="service-preview-card">
-                            <div className="service-preview-icon">🎵</div>
+                            <div className="service-preview-icon" aria-hidden="true">🎵</div>
                             <h3>Beat Leases</h3>
                             <p>Professionally crafted beats in Trap, Drill, R&amp;B, and more.</p>
                             <span className="service-preview-price">From $50</span>
                             <span className="service-preview-link">Browse Beats →</span>
                         </Link>
                         <Link to="/services" className="service-preview-card">
-                            <div className="service-preview-icon">🎚️</div>
+                            <div className="service-preview-icon" aria-hidden="true">🎚️</div>
                             <h3>Mixing &amp; Mastering</h3>
                             <p>Send your stems and get back a polished, release-ready record.</p>
                             <span className="service-preview-price">From $75</span>
                             <span className="service-preview-link">View Services →</span>
                         </Link>
                         <Link to="/services" className="service-preview-card">
-                            <div className="service-preview-icon">🎛️</div>
+                            <div className="service-preview-icon" aria-hidden="true">🎛️</div>
                             <h3>Full Production</h3>
                             <p>Complete song production from initial concept to final master.</p>
                             <span className="service-preview-price">From $250</span>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import SpotifyTrack from '../components/SpotifyTrack';
 import EmailCapture from '../components/EmailCapture';
 import usePageMeta from '../hooks/usePageMeta';
 import '../styles/Home.css';
+import '../styles/PageContent.css';
 
 const Home = () => {
     usePageMeta({

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -113,10 +113,7 @@ const Home = () => {
                         {featuredTracks.map((track, index) => (
                             <div key={index} className="track-item">
                                 <p className="track-credit">{track.description}</p>
-                                <SpotifyTrack
-                                    trackUrl={track.url}
-                                    description={track.description}
-                                />
+                                <SpotifyTrack trackUrl={track.url} />
                             </div>
                         ))}
                     </div>
@@ -130,13 +127,7 @@ const Home = () => {
             <section className="home-email-capture">
                 <div className="home-container">
                     <div className="email-capture-wrap">
-                        <div className="email-capture-copy">
-                            <h2>Get a Free Mix Feedback Session</h2>
-                            <p>Enter your email to receive a free review of your mix. I'll give you actionable notes to improve your sound.</p>
-                        </div>
-                        <div className="email-capture-form-wrap">
-                            <EmailCapture />
-                        </div>
+                        <EmailCapture />
                     </div>
                 </div>
             </section>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,9 +2,7 @@ import { Link } from 'react-router-dom';
 import SpotifyTrack from '../components/SpotifyTrack';
 import EmailCapture from '../components/EmailCapture';
 import usePageMeta from '../hooks/usePageMeta';
-import '../styles/PageContent.css';
 import '../styles/Home.css';
-
 
 const Home = () => {
     usePageMeta({
@@ -12,6 +10,7 @@ const Home = () => {
         description: 'Professional beats, mixing & mastering by RIQ. Buy WAV leases from $50, exclusive licenses from $200, mixing from $75.',
         canonicalPath: '/',
     });
+
     const featuredTracks = [
         {
             url: 'https://open.spotify.com/track/3rlbQrNDUyIpF5QPjpFCkV',
@@ -28,63 +27,120 @@ const Home = () => {
     ];
 
     return (
-        <div className="page-content">
-            <div className="hero-section">
-                <div className="hero-content">
-                    <h1>RIQ Music Production</h1>
-                    <p className="hero-subtitle">Professional Music Production, Mixing & Mastering</p>
-                    <p className="hero-description">
-                        Transform your musical vision into reality with professional production services. 
-                        From beat creation to final mastering, I deliver industry-standard quality that makes your music stand out.
-                    </p>
-                    <div className="hero-buttons">
-                        <Link to="/services" className="cta-button primary">Book a Session</Link>
-                        <Link to="/about" className="cta-button secondary">Learn More</Link>
-                    </div>
-                </div>
-            </div>
+        <div className="home-page">
 
-            <div className="featured-section">
-                <h2>Featured Work</h2>
-                <p>Listen to some of my recent productions and mixes</p>
-                
-                <div className="tracks-grid">
-                    {featuredTracks.map((track, index) => (
-                        <div key={index} className="track-item">
-                            <SpotifyTrack 
-                                trackUrl={track.url} 
-                                description={track.description}
-                            />
+            {/* Hero */}
+            <section className="home-hero">
+                <div className="home-container">
+                    <div className="hero-content">
+                        <p className="hero-eyebrow">Remote · Fast Turnaround · Premium Quality</p>
+                        <h1>Professional Music Production, Mixing &amp; Mastering</h1>
+                        <p className="hero-subtitle">
+                            Transform your sound with industry-standard quality.
+                            Remote services. Fast turnaround. Premium results.
+                        </p>
+                        <div className="hero-buttons">
+                            <Link to="/beats" className="btn-primary hero-btn">Browse Beats</Link>
+                            <Link to="/services" className="btn-secondary hero-btn">View Services</Link>
                         </div>
-                    ))}
+                    </div>
                 </div>
-                
-                <div className="featured-more">
-                    <Link to="/featured-work" className="cta-button secondary">View All Work</Link>
-                </div>
-            </div>
+            </section>
 
-            <div className="services-preview">
-                <h2>Services</h2>
-                <div className="services-grid">
-                    <div className="service-card">
-                        <h3>Beat Production</h3>
-                        <p>Custom beats tailored to your style and vision</p>
-                        <Link to="/beats" className="service-link">Explore Beats →</Link>
-                    </div>
-                    <div className="service-card">
-                        <h3>Mixing & Mastering</h3>
-                        <p>Professional mixing and mastering to industry standards</p>
-                        <Link to="/services" className="service-link">View Services →</Link>
-                    </div>
-                    <div className="service-card">
-                        <h3>Full Production</h3>
-                        <p>Complete song production from concept to final master</p>
-                        <Link to="/booking" className="service-link">Book Session →</Link>
+            {/* Stats Bar */}
+            <section className="home-stats">
+                <div className="home-container">
+                    <div className="stats-bar">
+                        <div className="stat-item">
+                            <span className="stat-number">50+</span>
+                            <span className="stat-label">Beats Available</span>
+                        </div>
+                        <div className="stat-divider" aria-hidden="true" />
+                        <div className="stat-item">
+                            <span className="stat-number">100+</span>
+                            <span className="stat-label">Tracks Mixed</span>
+                        </div>
+                        <div className="stat-divider" aria-hidden="true" />
+                        <div className="stat-item">
+                            <span className="stat-number">Remote</span>
+                            <span className="stat-label">Worldwide Service</span>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <EmailCapture />
+            </section>
+
+            {/* Services Preview */}
+            <section className="home-services">
+                <div className="home-container">
+                    <div className="section-header">
+                        <h2>What I Do</h2>
+                        <p className="section-subtitle">Everything you need to take your music to the next level</p>
+                    </div>
+                    <div className="services-cards">
+                        <Link to="/beats" className="service-preview-card">
+                            <div className="service-preview-icon">🎵</div>
+                            <h3>Beat Leases</h3>
+                            <p>Professionally crafted beats in Trap, Drill, R&amp;B, and more.</p>
+                            <span className="service-preview-price">From $50</span>
+                            <span className="service-preview-link">Browse Beats →</span>
+                        </Link>
+                        <Link to="/services" className="service-preview-card">
+                            <div className="service-preview-icon">🎚️</div>
+                            <h3>Mixing &amp; Mastering</h3>
+                            <p>Send your stems and get back a polished, release-ready record.</p>
+                            <span className="service-preview-price">From $75</span>
+                            <span className="service-preview-link">View Services →</span>
+                        </Link>
+                        <Link to="/services" className="service-preview-card">
+                            <div className="service-preview-icon">🎛️</div>
+                            <h3>Full Production</h3>
+                            <p>Complete song production from initial concept to final master.</p>
+                            <span className="service-preview-price">From $250</span>
+                            <span className="service-preview-link">Get Started →</span>
+                        </Link>
+                    </div>
+                </div>
+            </section>
+
+            {/* Featured Productions */}
+            <section className="home-featured">
+                <div className="home-container">
+                    <div className="section-header">
+                        <h2>Featured Productions</h2>
+                        <p className="section-subtitle">Recent work — mixed, mastered, and produced by RIQ</p>
+                    </div>
+                    <div className="tracks-grid">
+                        {featuredTracks.map((track, index) => (
+                            <div key={index} className="track-item">
+                                <p className="track-credit">{track.description}</p>
+                                <SpotifyTrack
+                                    trackUrl={track.url}
+                                    description={track.description}
+                                />
+                            </div>
+                        ))}
+                    </div>
+                    <div className="featured-more">
+                        <Link to="/featured-work" className="btn-secondary">See All Work →</Link>
+                    </div>
+                </div>
+            </section>
+
+            {/* Email Capture */}
+            <section className="home-email-capture">
+                <div className="home-container">
+                    <div className="email-capture-wrap">
+                        <div className="email-capture-copy">
+                            <h2>Get a Free Mix Feedback Session</h2>
+                            <p>Enter your email to receive a free review of your mix. I'll give you actionable notes to improve your sound.</p>
+                        </div>
+                        <div className="email-capture-form-wrap">
+                            <EmailCapture />
+                        </div>
+                    </div>
+                </div>
+            </section>
+
         </div>
     );
 };

--- a/src/styles/EmailCapture.css
+++ b/src/styles/EmailCapture.css
@@ -1,40 +1,37 @@
 .email-capture-section {
-  margin-top: 4rem;
-  padding: 3rem 1.5rem;
-  background: var(--color-neutral-1);
-  border-top: 1px solid var(--color-neutral-3);
-  border-bottom: 1px solid var(--color-neutral-3);
+  width: 100%;
 }
 
 .email-capture-inner {
-  max-width: 600px;
+  max-width: 480px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.25rem;
+  gap: 1rem;
   text-align: center;
 }
 
 .email-capture-copy h3 {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--text-dark);
-  margin-bottom: 0.3rem;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-heading);
+  margin-bottom: 0.25rem;
 }
 
 .email-capture-copy p {
-  color: var(--text-medium);
-  font-size: 0.9rem;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  margin: 0;
 }
 
 .email-capture-form {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.375rem;
   width: 100%;
-  max-width: 440px;
 }
 
 .email-capture-input-wrap {
@@ -45,63 +42,77 @@
 
 .email-capture-input-wrap input {
   flex: 1;
-  padding: 0.7rem 1rem;
-  border: 1.5px solid var(--color-neutral-3);
-  border-radius: 0.5rem;
-  background: var(--color-neutral-2, #1a1a1a);
-  color: var(--text-dark);
-  font-size: 0.95rem;
-  font-family: inherit;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  font-family: var(--font-body);
+  transition: border-color var(--transition-default), box-shadow var(--transition-default);
 }
 
 .email-capture-input-wrap input:focus {
   outline: none;
-  border-color: var(--color-accent-3);
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.email-capture-input-wrap input::placeholder {
+  color: var(--text-muted);
 }
 
 .email-capture-input-wrap button {
-  padding: 0.7rem 1.25rem;
-  background: var(--color-accent-3);
-  color: #000;
-  border: none;
-  border-radius: 0.5rem;
-  font-weight: 700;
-  font-size: 0.9rem;
+  padding: 0.75rem 1.375rem;
+  background: var(--accent-primary);
+  color: #FFFFFF;
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: 0.9375rem;
+  font-family: var(--font-body);
   cursor: pointer;
   white-space: nowrap;
-  transition: opacity 0.2s;
+  transition: all var(--transition-default);
 }
 
 .email-capture-input-wrap button:hover:not(:disabled) {
-  opacity: 0.88;
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
 .email-capture-input-wrap button:disabled {
-  opacity: 0.5;
+  opacity: 0.55;
   cursor: not-allowed;
+  transform: none;
 }
 
 .email-capture-confirm {
-  color: var(--color-accent-3);
+  color: var(--success);
   font-weight: 600;
   font-size: 1rem;
+  margin: 0;
 }
 
 .email-capture-field-error {
-  font-size: 0.8rem;
-  color: #ff6b6b;
+  font-size: 0.8125rem;
+  color: var(--error);
   text-align: left;
   width: 100%;
 }
 
 .email-capture-error {
-  color: #ff6b6b;
-  font-size: 0.85rem;
+  color: var(--error);
+  font-size: 0.875rem;
   margin: 0;
 }
 
 @media (max-width: 480px) {
   .email-capture-input-wrap {
     flex-direction: column;
+  }
+
+  .email-capture-input-wrap button {
+    width: 100%;
   }
 }

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -250,7 +250,7 @@
   margin-bottom: 2rem;
 }
 
-.email-capture-copy h2 {
+.email-capture-copy h3 {
   font-family: var(--font-display);
   font-size: 2.25rem;
   font-weight: 600;
@@ -338,7 +338,7 @@
     max-width: 280px;
   }
 
-  .email-capture-copy h2 {
+  .email-capture-copy h3 {
     font-size: 1.75rem;
   }
 }

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,34 +1,46 @@
-.hero-section {
+.home-page {
+  width: 100%;
+}
+
+.home-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* ─── Hero ─────────────────────────────────────────── */
+.home-hero {
+  background-color: var(--bg-primary);
+  padding: 7rem 0 6rem;
   text-align: center;
-  padding: 4rem 0;
-  background: linear-gradient(135deg, var(--color-accent-3) 0%, var(--color-lightest) 100%);
-  color: var(--text-dark);
-  border-radius: 12px;
-  margin-bottom: 3rem;
-  border: 2px solid var(--color-neutral-3);
-  box-shadow: 0 4px 16px rgba(45, 45, 45, 0.1);
+}
+
+.hero-eyebrow {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 1.25rem;
 }
 
 .hero-content h1 {
-  font-size: 3rem;
-  margin-bottom: 1rem;
+  font-family: var(--font-display);
+  font-size: 3.5rem;
   font-weight: 700;
-  color: var(--text-dark);
+  color: var(--text-heading);
+  line-height: 1.15;
+  max-width: 760px;
+  margin: 0 auto 1.25rem;
 }
 
 .hero-subtitle {
-  font-size: 1.5rem;
-  margin-bottom: 1.5rem;
-  color: var(--text-dark);
-  font-weight: 600;
-}
-
-.hero-description {
-  font-size: 1.1rem;
-  max-width: 600px;
-  margin: 0 auto 2rem;
-  line-height: 1.6;
-  color: var(--text-medium);
+  font-size: 1.125rem;
+  color: var(--text-secondary);
+  max-width: 520px;
+  margin: 0 auto 2.5rem;
+  line-height: 1.7;
 }
 
 .hero-buttons {
@@ -38,174 +50,295 @@
   flex-wrap: wrap;
 }
 
-.featured-section {
-  margin: 4rem 0;
-  text-align: center;
+.hero-btn {
+  min-width: 160px;
 }
 
-.featured-section h2 {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-  color: var(--text-dark);
+/* ─── Stats Bar ─────────────────────────────────────── */
+.home-stats {
+  padding: 0 0 4rem;
+}
+
+.stats-bar {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 3rem;
+  gap: 2rem;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.stat-number {
+  font-family: var(--font-display);
+  font-size: 2rem;
   font-weight: 700;
+  color: var(--text-heading);
+  line-height: 1;
 }
 
-.featured-section > p {
-  font-size: 1.1rem;
-  color: var(--text-medium);
+.stat-label {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.3;
+}
+
+.stat-divider {
+  width: 1px;
+  height: 40px;
+  background-color: var(--border-default);
+  flex-shrink: 0;
+}
+
+/* ─── Section Header ─────────────────────────────────── */
+.section-header {
+  text-align: center;
   margin-bottom: 3rem;
+}
+
+.section-header h2 {
+  font-family: var(--font-display);
+  font-size: 2.25rem;
+  font-weight: 600;
+  color: var(--text-heading);
+  margin-bottom: 0.75rem;
+}
+
+.section-subtitle {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* ─── Services Preview ───────────────────────────────── */
+.home-services {
+  padding: 4rem 0;
+  background-color: var(--bg-secondary);
+}
+
+.services-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.service-preview-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-decoration: none;
+  transition: box-shadow var(--transition-default), transform var(--transition-default), border-color var(--transition-default);
+}
+
+.service-preview-card:hover {
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-3px);
+  border-color: var(--border-strong);
+  color: inherit;
+}
+
+.service-preview-icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.service-preview-card h3 {
+  font-family: var(--font-body);
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-heading);
+  margin: 0;
+}
+
+.service-preview-card p {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.6;
+  flex: 1;
+}
+
+.service-preview-price {
+  font-family: var(--font-body);
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--accent-primary);
+}
+
+.service-preview-link {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--accent-primary);
+  margin-top: 0.25rem;
+  transition: color var(--transition-fast);
+}
+
+.service-preview-card:hover .service-preview-link {
+  color: var(--accent-hover);
+}
+
+/* ─── Featured Productions ───────────────────────────── */
+.home-featured {
+  padding: 5rem 0;
 }
 
 .tracks-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 2rem;
-  margin-top: 2rem;
-}
-
-.featured-more {
-  margin-top: 3rem;
-  text-align: center;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
 }
 
 .track-item {
-  background: var(--color-neutral-1);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 4px 12px rgba(45, 45, 45, 0.1);
-  transition: all 0.3s ease;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-default);
 }
 
 .track-item:hover {
-  transform: translateY(-5px);
-  border-color: var(--color-accent-3);
-  box-shadow: 0 8px 24px rgba(45, 45, 45, 0.15);
+  box-shadow: var(--shadow-md);
 }
 
-.track-description {
+.track-credit {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--text-dark);
-  margin-bottom: 1rem;
-  text-align: center;
-  background: var(--color-accent-3);
-  padding: 0.5rem 1rem;
-  border-radius: 1rem;
-  display: inline-block;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.75px;
 }
 
-.spotify-track iframe {
-  border-radius: 8px;
-}
-
-.services-preview {
-  margin: 4rem 0;
+.featured-more {
   text-align: center;
 }
 
-.services-preview h2 {
-  font-size: 2.5rem;
-  margin-bottom: 3rem;
-  color: var(--text-dark);
-  font-weight: 700;
+/* ─── Email Capture Section ──────────────────────────── */
+.home-email-capture {
+  background-color: var(--almond);
+  padding: 5rem 0;
 }
 
-.services-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 2rem;
+.email-capture-wrap {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
 }
 
-.service-card {
-  background: var(--color-neutral-1);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 12px;
-  padding: 2rem;
-  box-shadow: 0 4px 12px rgba(45, 45, 45, 0.1);
-  transition: all 0.3s ease;
-  text-align: left;
+.email-capture-copy {
+  margin-bottom: 2rem;
 }
 
-.service-card:hover {
-  transform: translateY(-5px);
-  border-color: var(--color-accent-3);
-  box-shadow: 0 8px 24px rgba(45, 45, 45, 0.15);
-}
-
-.service-card h3 {
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-  color: var(--text-dark);
-  font-weight: 700;
-}
-
-.service-card p {
-  color: var(--text-medium);
-  margin-bottom: 1.5rem;
-  line-height: 1.6;
-}
-
-.service-link {
-  color: var(--text-dark);
-  text-decoration: none;
+.email-capture-copy h2 {
+  font-family: var(--font-display);
+  font-size: 2.25rem;
   font-weight: 600;
-  transition: all 0.3s ease;
-  background: var(--color-accent-3);
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  display: inline-block;
-  border: 2px solid var(--color-accent-3);
+  color: var(--text-heading);
+  margin-bottom: 0.75rem;
 }
 
-.service-link:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-1px);
+.email-capture-copy p {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 480px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+/* Resets for EmailCapture component rendered inside the section */
+.email-capture-form-wrap .email-capture-section {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+}
+
+/* ─── Responsive ─────────────────────────────────────── */
+@media (max-width: 900px) {
+  .services-cards {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .tracks-grid {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 @media (max-width: 768px) {
+  .home-hero {
+    padding: 5rem 0 4rem;
+  }
+
+  .hero-content h1 {
+    font-size: 2.5rem;
+  }
+
+  .stats-bar {
+    padding: 1.5rem 2rem;
+    gap: 1rem;
+  }
+
+  .stat-number {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .services-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .tracks-grid {
+    grid-template-columns: 1fr;
+  }
+
   .hero-content h1 {
     font-size: 2rem;
   }
-  
-  .hero-subtitle {
-    font-size: 1.2rem;
+
+  .stats-bar {
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.5rem;
   }
-  
+
+  .stat-divider {
+    width: 60px;
+    height: 1px;
+  }
+
   .hero-buttons {
     flex-direction: column;
     align-items: center;
   }
-  
-  .tracks-grid,
-  .services-grid {
-    grid-template-columns: 1fr;
-  }
-  
-  .featured-section h2,
-  .services-preview h2 {
-    font-size: 2rem;
-  }
-}
 
-/* High contrast mode support */
-@media (prefers-contrast: high) {
-  .hero-section {
-    border-width: 3px;
+  .hero-btn {
+    width: 100%;
+    max-width: 280px;
   }
-  
-  .track-item,
-  .service-card {
-    border-width: 3px;
-  }
-  
-  .service-link {
-    border-width: 3px;
-  }
-}
 
-/* Focus styles for accessibility */
-.service-link:focus {
-  outline: 3px solid var(--color-accent-3);
-  outline-offset: 2px;
+  .email-capture-copy h2 {
+    font-size: 1.75rem;
+  }
 }

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -267,7 +267,7 @@
 }
 
 /* Resets for EmailCapture component rendered inside the section */
-.email-capture-form-wrap .email-capture-section {
+.email-capture-wrap .email-capture-section {
   margin: 0;
   padding: 0;
   background: transparent;

--- a/src/styles/PageContent.css
+++ b/src/styles/PageContent.css
@@ -32,60 +32,58 @@
 
 .content-section h3 {
   margin-bottom: 1rem;
-  color: #e1e5e9;
+  color: var(--text-heading);
 }
 
 .error-message {
-  color: #f85149;
+  color: var(--error);
   font-size: 0.9rem;
   margin-top: 0.5rem;
-  padding: 0.5rem;
-  background-color: #161b22;
-  border: 1px solid #f85149;
-  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  background-color: rgba(184, 92, 92, 0.08);
+  border: 1px solid var(--error);
+  border-radius: var(--radius-md);
 }
 
 .loading-indicator {
   text-align: center;
   padding: 2rem;
-  color: #8b949e;
+  color: var(--text-secondary);
 }
 
+/* Generic CTA button styles used by older pages */
 .cta-button {
   display: inline-block;
-  padding: 12px 24px;
+  padding: 0.75rem 1.5rem;
   text-decoration: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-weight: 600;
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
   text-align: center;
-  transition: all 0.3s ease;
-  border: none;
+  transition: all var(--transition-default);
   cursor: pointer;
-  font-size: 1rem;
 }
 
 .cta-button.primary {
-  background: var(--color-accent-3);
-  color: var(--text-dark);
-  border: 2px solid var(--color-accent-3);
-  box-shadow: 0 4px 12px rgba(254, 200, 154, 0.3);
+  background: var(--accent-primary);
+  color: #FFFFFF;
+  border: 1.5px solid var(--accent-primary);
 }
 
 .cta-button.primary:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(254, 197, 187, 0.4);
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  transform: translateY(-1px);
 }
 
 .cta-button.secondary {
-  background-color: transparent;
-  color: var(--text-dark);
-  border: 2px solid var(--color-neutral-3);
+  background: transparent;
+  color: var(--accent-primary);
+  border: 1.5px solid var(--accent-primary);
 }
 
 .cta-button.secondary:hover {
-  background: var(--color-light);
-  border-color: var(--color-accent-3);
-  color: var(--text-dark);
+  background: var(--accent-glow);
+  transform: translateY(-1px);
 }


### PR DESCRIPTION
## Summary
- **Hero**: Cream background, Playfair Display H1, eyebrow tag, Browse Beats + View Services CTAs (removed "Book a Session")
- **Stats bar**: White card with 50+ Beats, 100+ Tracks Mixed, Remote Worldwide
- **Services preview**: 3 cards (Beat Leases $50+, Mixing $75+, Full Production $250+) — no booking link
- **Featured productions**: Spotify embeds with credit labels
- **Email capture**: Almond-tinted section, "Get a Free Mix Feedback Session" headline

## Test plan
- [ ] Build passes clean
- [ ] Hero loads with warm cream background and Playfair Display font
- [ ] "Browse Beats" goes to /beats, "View Services" goes to /services
- [ ] Stats bar renders all 3 items
- [ ] 3 service cards render and link correctly
- [ ] Spotify embeds load
- [ ] Email form submits and shows confirmation
- [ ] Responsive at 390px mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)