### PR TITLE
[Phase D] Redesign Beat Store — list/grid views, mood filters, persistent audio player

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import NavBar from './components/NavBar.tsx'
 import Footer from './components/Footer.tsx'
 import { CartProvider } from './components/cart/CartProvider'
 import CartDrawer from './components/cart/CartDrawer'
+import { AudioPlayerProvider, useAudioPlayer } from './components/AudioPlayerContext'
+import AudioPlayer from './components/AudioPlayer'
 
 const NotFound = () => (
   <div className="not-found">
@@ -22,26 +24,42 @@ const NotFound = () => (
   </div>
 );
 
+function AppInner() {
+  const { currentBeat, isPlaying, togglePlayPause, stopBeat } = useAudioPlayer();
+
+  return (
+    <div className="app-container" style={{ paddingBottom: currentBeat ? 'var(--audio-player-height, 72px)' : undefined }}>
+      <NavBar />
+      <main className="main-content">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/beats" element={<Beats />} />
+          <Route path="/services" element={<Services />} />
+          <Route path="/featured-work" element={<FeaturedWork />} />
+          <Route path="/success" element={<Success />} />
+          <Route path="/admin" element={<Admin />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </main>
+      <Footer />
+      <CartDrawer />
+      <AudioPlayer
+        currentBeat={currentBeat}
+        isPlaying={isPlaying}
+        onPlayPause={togglePlayPause}
+        onEnded={stopBeat}
+      />
+    </div>
+  );
+}
+
 function App() {
   return (
     <CartProvider>
-      <div className="app-container">
-        <NavBar />
-        <main className="main-content">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/beats" element={<Beats />} />
-            <Route path="/services" element={<Services />} />
-            <Route path="/featured-work" element={<FeaturedWork />} />
-            <Route path="/success" element={<Success />} />
-            <Route path="/admin" element={<Admin />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </main>
-        <Footer />
-        <CartDrawer />
-      </div>
+      <AudioPlayerProvider>
+        <AppInner />
+      </AudioPlayerProvider>
     </CartProvider>
   )
 }

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useRef, useState } from 'react';
+import '../styles/AudioPlayer.css';
+import type { Beat } from '../types/beats';
+
+interface AudioPlayerProps {
+  currentBeat: Beat | null;
+  isPlaying: boolean;
+  onPlayPause: () => void;
+  onEnded: () => void;
+}
+
+const AudioPlayer: React.FC<AudioPlayerProps> = ({ currentBeat, isPlaying, onPlayPause, onEnded }) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(0.8);
+
+  const formatTime = (time: number) => {
+    if (!isFinite(time)) return '0:00';
+    const m = Math.floor(time / 60);
+    const s = Math.floor(time % 60);
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  };
+
+  // Load new beat
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || !currentBeat?.preview_path) return;
+    audio.src = currentBeat.preview_path;
+    audio.load();
+    setCurrentTime(0);
+    setDuration(0);
+  }, [currentBeat?.beat_id]);
+
+  // Play/pause
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.play().catch(console.error);
+    } else {
+      audio.pause();
+    }
+  }, [isPlaying]);
+
+  // Volume
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = volume;
+    }
+  }, [volume]);
+
+  const handleTimeUpdate = () => {
+    if (audioRef.current) setCurrentTime(audioRef.current.currentTime);
+  };
+
+  const handleLoadedMetadata = () => {
+    if (audioRef.current) setDuration(audioRef.current.duration);
+  };
+
+  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newTime = Number(e.target.value);
+    setCurrentTime(newTime);
+    if (audioRef.current) audioRef.current.currentTime = newTime;
+  };
+
+  const progressPercent = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  if (!currentBeat) return null;
+
+  return (
+    <div className="audio-player" role="region" aria-label="Audio player">
+      <audio
+        ref={audioRef}
+        onTimeUpdate={handleTimeUpdate}
+        onLoadedMetadata={handleLoadedMetadata}
+        onEnded={onEnded}
+      />
+
+      <div className="audio-player-inner">
+        {/* Cover + Title */}
+        <div className="ap-track-info">
+          <img
+            src={currentBeat.cover_path}
+            alt={currentBeat.title}
+            className="ap-cover"
+          />
+          <div className="ap-meta">
+            <span className="ap-title">{currentBeat.title}</span>
+            <span className="ap-detail">{currentBeat.bpm} BPM · {currentBeat.key}</span>
+          </div>
+        </div>
+
+        {/* Controls */}
+        <div className="ap-controls">
+          <button
+            className="ap-play-btn"
+            onClick={onPlayPause}
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <rect x="6" y="4" width="4" height="16" rx="1"/>
+                <rect x="14" y="4" width="4" height="16" rx="1"/>
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <polygon points="5,3 19,12 5,21"/>
+              </svg>
+            )}
+          </button>
+
+          <div className="ap-progress-wrap">
+            <span className="ap-time">{formatTime(currentTime)}</span>
+            <div className="ap-progress-track" role="none">
+              <div
+                className="ap-progress-fill"
+                style={{ width: `${progressPercent}%` }}
+              />
+              <input
+                type="range"
+                className="ap-seek"
+                min={0}
+                max={duration || 0}
+                step={0.1}
+                value={currentTime}
+                onChange={handleSeek}
+                aria-label="Seek"
+              />
+            </div>
+            <span className="ap-time">{formatTime(duration)}</span>
+          </div>
+        </div>
+
+        {/* Volume */}
+        <div className="ap-volume">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+            {volume > 0 && <path d="M19.07 4.93a10 10 0 010 14.14"/>}
+            {volume > 0 && <path d="M15.54 8.46a5 5 0 010 7.07"/>}
+          </svg>
+          <input
+            type="range"
+            className="ap-volume-slider"
+            min={0}
+            max={1}
+            step={0.05}
+            value={volume}
+            onChange={e => setVolume(Number(e.target.value))}
+            aria-label="Volume"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AudioPlayer;

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -22,7 +22,7 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ currentBeat, isPlaying, onPla
     return `${m}:${s.toString().padStart(2, '0')}`;
   };
 
-  // Load new beat
+  // Load new beat — and auto-play if already in playing state
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio || !currentBeat?.preview_path) return;
@@ -30,9 +30,12 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ currentBeat, isPlaying, onPla
     audio.load();
     setCurrentTime(0);
     setDuration(0);
-  }, [currentBeat?.beat_id]);
+    if (isPlaying) {
+      audio.play().catch(console.error);
+    }
+  }, [currentBeat?.beat_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Play/pause
+  // Play/pause (handles toggling on the current beat)
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -31,7 +31,10 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ currentBeat, isPlaying, onPla
     setCurrentTime(0);
     setDuration(0);
     if (isPlaying) {
-      audio.play().catch(console.error);
+      audio.play().catch((err) => {
+        console.error('Audio play failed:', err);
+        onEnded(); // resets isPlaying in the context
+      });
     }
   }, [currentBeat?.beat_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -40,11 +43,14 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ currentBeat, isPlaying, onPla
     const audio = audioRef.current;
     if (!audio) return;
     if (isPlaying) {
-      audio.play().catch(console.error);
+      audio.play().catch((err) => {
+        console.error('Audio play failed:', err);
+        onEnded();
+      });
     } else {
       audio.pause();
     }
-  }, [isPlaying]);
+  }, [isPlaying]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Volume
   useEffect(() => {

--- a/src/components/AudioPlayerContext.tsx
+++ b/src/components/AudioPlayerContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useState } from 'react';
+import type { Beat } from '../types/beats';
+
+interface AudioPlayerContextType {
+  currentBeat: Beat | null;
+  isPlaying: boolean;
+  playBeat: (beat: Beat) => void;
+  pauseBeat: () => void;
+  togglePlayPause: () => void;
+  stopBeat: () => void;
+}
+
+const AudioPlayerContext = createContext<AudioPlayerContextType | undefined>(undefined);
+
+export const AudioPlayerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [currentBeat, setCurrentBeat] = useState<Beat | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const playBeat = (beat: Beat) => {
+    setCurrentBeat(beat);
+    setIsPlaying(true);
+  };
+
+  const pauseBeat = () => setIsPlaying(false);
+
+  const togglePlayPause = () => setIsPlaying(prev => !prev);
+
+  const stopBeat = () => {
+    setIsPlaying(false);
+    setCurrentBeat(null);
+  };
+
+  return (
+    <AudioPlayerContext.Provider value={{ currentBeat, isPlaying, playBeat, pauseBeat, togglePlayPause, stopBeat }}>
+      {children}
+    </AudioPlayerContext.Provider>
+  );
+};
+
+export const useAudioPlayer = () => {
+  const ctx = useContext(AudioPlayerContext);
+  if (!ctx) throw new Error('useAudioPlayer must be used within AudioPlayerProvider');
+  return ctx;
+};

--- a/src/components/AudioPlayerContext.tsx
+++ b/src/components/AudioPlayerContext.tsx
@@ -23,7 +23,10 @@ export const AudioPlayerProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
   const pauseBeat = () => setIsPlaying(false);
 
-  const togglePlayPause = () => setIsPlaying(prev => !prev);
+  const togglePlayPause = () => {
+    if (!currentBeat) return;
+    setIsPlaying(prev => !prev);
+  };
 
   const stopBeat = () => {
     setIsPlaying(false);

--- a/src/components/beats/BeatCard.tsx
+++ b/src/components/beats/BeatCard.tsx
@@ -1,192 +1,148 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React from 'react';
 import { useCart } from '../cart/CartProvider';
+import { useAudioPlayer } from '../AudioPlayerContext';
 import type { Beat } from '../../types/beats';
 
 interface BeatCardProps {
   beat: Beat;
-  isPlaying?: boolean;
-  onPlay?: (beatId: string) => void;
-  onPause?: () => void;
+  view?: 'list' | 'grid';
 }
 
-const BeatCard: React.FC<BeatCardProps> = ({ beat, isPlaying = false, onPlay, onPause }) => {
-  const hasPreview = Boolean(beat.preview_path);
-  const [isLoading, setIsLoading] = useState(false);
-  const [duration, setDuration] = useState(0);
-  const [currentTime, setCurrentTime] = useState(0);
-  const audioRef = useRef<HTMLAudioElement>(null);
+const BeatCard: React.FC<BeatCardProps> = ({ beat, view = 'list' }) => {
   const { addBeatToCart } = useCart();
+  const { currentBeat, isPlaying, playBeat, pauseBeat } = useAudioPlayer();
 
-  const formatTime = (time: number) => {
-    const minutes = Math.floor(time / 60);
-    const seconds = Math.floor(time % 60);
-    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-  };
+  const isThisBeatPlaying = currentBeat?.beat_id === beat.beat_id && isPlaying;
+  const hasPreview = Boolean(beat.preview_path);
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD'
-    }).format(amount);
-  };
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0 }).format(amount);
 
-  useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio) return;
-
-    const handleLoadedMetadata = () => {
-      setDuration(audio.duration);
-      setIsLoading(false);
-    };
-
-    const handleTimeUpdate = () => {
-      setCurrentTime(audio.currentTime);
-    };
-
-    const handleEnded = () => {
-      if (onPause) onPause();
-      setCurrentTime(0);
-    };
-
-    const handleLoadStart = () => {
-      setIsLoading(true);
-    };
-
-    audio.addEventListener('loadedmetadata', handleLoadedMetadata);
-    audio.addEventListener('timeupdate', handleTimeUpdate);
-    audio.addEventListener('ended', handleEnded);
-    audio.addEventListener('loadstart', handleLoadStart);
-
-    return () => {
-      audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
-      audio.removeEventListener('timeupdate', handleTimeUpdate);
-      audio.removeEventListener('ended', handleEnded);
-      audio.removeEventListener('loadstart', handleLoadStart);
-    };
-  }, [onPause]);
-
-  useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio) return;
-
-    if (isPlaying) {
-      audio.play().catch(console.error);
+  const handlePlayPause = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!hasPreview) return;
+    if (isThisBeatPlaying) {
+      pauseBeat();
     } else {
-      audio.pause();
-    }
-  }, [isPlaying]);
-
-  const handlePlayPause = () => {
-    if (isPlaying) {
-      if (onPause) onPause();
-    } else {
-      if (onPlay) onPlay(beat.beat_id);
+      playBeat(beat);
     }
   };
 
-  const handleAddToCart = (licenseType: 'lease' | 'exclusive') => {
+  const handleAddToCart = (e: React.MouseEvent, licenseType: 'lease' | 'exclusive') => {
+    e.stopPropagation();
     const price = licenseType === 'lease' ? beat.lease_price : beat.exclusive_price;
-    addBeatToCart(
-      {
-        beat_id: beat.beat_id,
-        title: beat.title,
-        cover_path: beat.cover_path
-      },
-      licenseType,
-      price
-    );
+    addBeatToCart({ beat_id: beat.beat_id, title: beat.title, cover_path: beat.cover_path }, licenseType, price);
   };
 
-  const progressPercentage = duration > 0 ? (currentTime / duration) * 100 : 0;
-
-  return (
-    <div className="beat-card">
-      <div className="beat-cover">
-        <img src={beat.cover_path} alt={beat.title} />
-        
-        {/* Play/Pause Overlay */}
-        <div className="play-overlay">
-          {hasPreview ? (
-            <button
-              className={`play-btn ${isPlaying ? 'playing' : ''}`}
-              onClick={handlePlayPause}
-              disabled={isLoading}
-              aria-label={isPlaying ? 'Pause preview' : 'Play preview'}
-            >
-              {isLoading ? (
-                <div className="loading-spinner"></div>
-              ) : isPlaying ? (
-                <span className="pause-icon">⏸</span>
-              ) : (
-                <span className="play-icon">▶</span>
-              )}
-            </button>
-          ) : (
-            <span className="no-preview-label">Preview coming soon</span>
-          )}
+  if (view === 'grid') {
+    return (
+      <div
+        className={`beat-card-grid${isThisBeatPlaying ? ' is-playing' : ''}`}
+        role="article"
+        aria-label={beat.title}
+      >
+        <div className="bcg-cover" onClick={handlePlayPause}>
+          <img src={beat.cover_path} alt={beat.title} loading="lazy" />
+          <div className="bcg-play-overlay" aria-hidden="true">
+            {isThisBeatPlaying ? (
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="white">
+                <rect x="6" y="4" width="4" height="16" rx="1"/>
+                <rect x="14" y="4" width="4" height="16" rx="1"/>
+              </svg>
+            ) : (
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="white">
+                <polygon points="5,3 19,12 5,21"/>
+              </svg>
+            )}
+          </div>
         </div>
-
-        {/* Progress Bar */}
-        {isPlaying && (
-          <div className="progress-bar">
-            <div 
-              className="progress-fill" 
-              style={{ width: `${progressPercentage}%` }}
-            ></div>
+        <div className="bcg-info">
+          <h3 className="bcg-title">{beat.title}</h3>
+          <div className="bcg-meta">
+            <span>{beat.bpm} BPM</span>
+            <span>·</span>
+            <span>{beat.key}</span>
+            <span>·</span>
+            <span>{beat.genres[0]}</span>
           </div>
-        )}
-
-        {/* Time Display */}
-        {isPlaying && (
-          <div className="time-display">
-            {formatTime(currentTime)} / {formatTime(duration)}
+          <div className="beat-buy-btns">
+            <button
+              className="beat-btn-lease"
+              onClick={(e) => handleAddToCart(e, 'lease')}
+            >
+              Lease {formatCurrency(beat.lease_price)}
+            </button>
+            <button
+              className="beat-btn-exclusive"
+              onClick={(e) => handleAddToCart(e, 'exclusive')}
+            >
+              Excl. {formatCurrency(beat.exclusive_price)}
+            </button>
           </div>
-        )}
+        </div>
       </div>
+    );
+  }
 
-      <div className="beat-info">
-        <h3 className="beat-title">{beat.title}</h3>
-        
-        <div className="beat-metadata">
-          <span className="beat-bpm">{beat.bpm} BPM</span>
-          <span className="beat-key">{beat.key}</span>
-          {beat.genres.map((genre, index) => (
-            <span key={index} className="beat-genre">{genre}</span>
+  // Default: list view
+  return (
+    <div
+      className={`beat-card-list${isThisBeatPlaying ? ' is-playing' : ''}`}
+      role="article"
+      aria-label={beat.title}
+    >
+      <button
+        className="bcl-play-btn"
+        onClick={handlePlayPause}
+        disabled={!hasPreview}
+        aria-label={isThisBeatPlaying ? `Pause ${beat.title}` : `Play ${beat.title}`}
+      >
+        {isThisBeatPlaying ? (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <rect x="6" y="4" width="4" height="16" rx="1"/>
+            <rect x="14" y="4" width="4" height="16" rx="1"/>
+          </svg>
+        ) : (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <polygon points="5,3 19,12 5,21"/>
+          </svg>
+        )}
+      </button>
+
+      <img src={beat.cover_path} alt={beat.title} className="bcl-cover" loading="lazy" />
+
+      <div className="bcl-info">
+        <span className="bcl-title">{beat.title}</span>
+        <div className="bcl-tags">
+          {beat.mood?.map(m => (
+            <span key={m} className="bcl-tag bcl-tag-mood">{m}</span>
+          ))}
+          {beat.tags?.slice(0, 2).map(t => (
+            <span key={t} className="bcl-tag">#{t}</span>
           ))}
         </div>
-
-        {beat.tags && beat.tags.length > 0 && (
-          <div className="beat-tags">
-            {beat.tags.map((tag, index) => (
-              <span key={index} className="beat-tag">#{tag}</span>
-            ))}
-          </div>
-        )}
-
-        <div className="beat-pricing">
-          <button 
-            className="lease-btn"
-            onClick={() => handleAddToCart('lease')}
-          >
-            Lease - {formatCurrency(beat.lease_price)}
-          </button>
-          <button 
-            className="exclusive-btn"
-            onClick={() => handleAddToCart('exclusive')}
-          >
-            Exclusive - {formatCurrency(beat.exclusive_price)}
-          </button>
-        </div>
       </div>
 
-      {/* Audio element — only rendered when a preview URL exists */}
-      {hasPreview && (
-        <audio
-          ref={audioRef}
-          preload="metadata"
-          src={beat.preview_path}
-        />
-      )}
+      <div className="bcl-meta">
+        <span className="bcl-bpm">{beat.bpm} BPM</span>
+        <span className="bcl-key">{beat.key}</span>
+        <span className="bcl-genre">{beat.genres[0]}</span>
+      </div>
+
+      <div className="beat-buy-btns">
+        <button
+          className="beat-btn-lease"
+          onClick={(e) => handleAddToCart(e, 'lease')}
+        >
+          Lease {formatCurrency(beat.lease_price)}
+        </button>
+        <button
+          className="beat-btn-exclusive"
+          onClick={(e) => handleAddToCart(e, 'exclusive')}
+        >
+          Excl. {formatCurrency(beat.exclusive_price)}
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/beats/BeatCard.tsx
+++ b/src/components/beats/BeatCard.tsx
@@ -41,21 +41,28 @@ const BeatCard: React.FC<BeatCardProps> = ({ beat, view = 'list' }) => {
         role="article"
         aria-label={beat.title}
       >
-        <div className="bcg-cover" onClick={handlePlayPause}>
-          <img src={beat.cover_path} alt={beat.title} loading="lazy" />
-          <div className="bcg-play-overlay" aria-hidden="true">
-            {isThisBeatPlaying ? (
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="white">
-                <rect x="6" y="4" width="4" height="16" rx="1"/>
-                <rect x="14" y="4" width="4" height="16" rx="1"/>
-              </svg>
-            ) : (
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="white">
-                <polygon points="5,3 19,12 5,21"/>
-              </svg>
-            )}
-          </div>
-        </div>
+        <button
+          className="bcg-cover"
+          onClick={handlePlayPause}
+          disabled={!hasPreview}
+          aria-label={isThisBeatPlaying ? `Pause ${beat.title}` : `Play ${beat.title}`}
+        >
+          <img src={beat.cover_path} alt="" loading="lazy" />
+          {hasPreview && (
+            <div className="bcg-play-overlay" aria-hidden="true">
+              {isThisBeatPlaying ? (
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="white">
+                  <rect x="6" y="4" width="4" height="16" rx="1"/>
+                  <rect x="14" y="4" width="4" height="16" rx="1"/>
+                </svg>
+              ) : (
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="white">
+                  <polygon points="5,3 19,12 5,21"/>
+                </svg>
+              )}
+            </div>
+          )}
+        </button>
         <div className="bcg-info">
           <h3 className="bcg-title">{beat.title}</h3>
           <div className="bcg-meta">

--- a/src/components/beats/BeatFilters.tsx
+++ b/src/components/beats/BeatFilters.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { BeatFilters } from '../../types/beats';
-import { GENRES, MOODS } from '../../types/beats';
+import { GENRES, MOODS, KEYS, BPM_RANGES } from '../../types/beats';
 
 interface BeatFiltersProps {
   filters: BeatFilters;
@@ -106,8 +106,7 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
               onChange={e => onFiltersChange({ ...filters, key: e.target.value || undefined })}
             >
               <option value="">Any Key</option>
-              {['C','C#','D','D#','E','F','F#','G','G#','A','A#','B',
-                'Cm','C#m','Dm','D#m','Em','Fm','F#m','Gm','G#m','Am','A#m','Bm'].map(k => (
+              {KEYS.map(k => (
                 <option key={k} value={k}>{k}</option>
               ))}
             </select>
@@ -118,7 +117,7 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
               <input
                 type="number"
                 className="bfb-bpm-input"
-                min={60} max={200} step={5}
+                min={BPM_RANGES.min} max={BPM_RANGES.max} step={BPM_RANGES.step}
                 placeholder="Min"
                 value={filters.bpmMin || ''}
                 onChange={e => onFiltersChange({ ...filters, bpmMin: e.target.value ? parseInt(e.target.value) : undefined })}
@@ -128,7 +127,7 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
               <input
                 type="number"
                 className="bfb-bpm-input"
-                min={60} max={200} step={5}
+                min={BPM_RANGES.min} max={BPM_RANGES.max} step={BPM_RANGES.step}
                 placeholder="Max"
                 value={filters.bpmMax || ''}
                 onChange={e => onFiltersChange({ ...filters, bpmMax: e.target.value ? parseInt(e.target.value) : undefined })}

--- a/src/components/beats/BeatFilters.tsx
+++ b/src/components/beats/BeatFilters.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { BeatFilters } from '../../types/beats';
-import { GENRES, KEYS, BPM_RANGES } from '../../types/beats';
+import { GENRES, MOODS } from '../../types/beats';
 
 interface BeatFiltersProps {
   filters: BeatFilters;
@@ -8,118 +8,136 @@ interface BeatFiltersProps {
   onClearFilters: () => void;
 }
 
-const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({ 
-  filters, 
-  onFiltersChange, 
-  onClearFilters 
+const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
+  filters,
+  onFiltersChange,
+  onClearFilters
 }) => {
-  const updateFilter = (key: keyof BeatFilters, value: BeatFilters[typeof key]) => {
-    onFiltersChange({
-      ...filters,
-      [key]: value
-    });
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  const setGenre = (genre: string | undefined) => {
+    onFiltersChange({ ...filters, genre });
   };
 
-  const hasActiveFilters = Object.values(filters).some(value => 
-    value !== undefined && value !== '' && value !== null
-  );
+  const setMood = (mood: string | undefined) => {
+    onFiltersChange({ ...filters, mood });
+  };
+
+  const hasActive = Object.values(filters).some(v => v !== undefined && v !== '');
 
   return (
-    <div className="beat-filters">
-      <div className="filters-header">
-        <h3>Filter Beats</h3>
-        {hasActiveFilters && (
-          <button 
-            className="clear-filters-btn"
-            onClick={onClearFilters}
+    <div className="beat-filters-bar">
+      {/* Search */}
+      <div className="bfb-search-wrap">
+        <svg className="bfb-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="8"/>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>
+        <input
+          type="search"
+          className="bfb-search"
+          placeholder="Search beats..."
+          value={filters.search || ''}
+          onChange={e => onFiltersChange({ ...filters, search: e.target.value || undefined })}
+          aria-label="Search beats"
+        />
+      </div>
+
+      {/* Mood pills */}
+      <div className="bfb-pills-row" role="group" aria-label="Filter by mood">
+        <button
+          className={`bfb-pill${!filters.mood ? ' active' : ''}`}
+          onClick={() => setMood(undefined)}
+        >
+          All
+        </button>
+        {MOODS.map(mood => (
+          <button
+            key={mood}
+            className={`bfb-pill${filters.mood === mood ? ' active' : ''}`}
+            onClick={() => setMood(filters.mood === mood ? undefined : mood)}
           >
+            {mood}
+          </button>
+        ))}
+      </div>
+
+      {/* Genre + More Filters row */}
+      <div className="bfb-bottom-row">
+        <div className="bfb-genre-wrap">
+          <label htmlFor="bfb-genre" className="bfb-label">Genre</label>
+          <select
+            id="bfb-genre"
+            className="bfb-select"
+            value={filters.genre || ''}
+            onChange={e => setGenre(e.target.value || undefined)}
+          >
+            <option value="">All Genres</option>
+            {GENRES.map(g => (
+              <option key={g} value={g}>{g}</option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          className={`bfb-more-btn${moreOpen ? ' open' : ''}`}
+          onClick={() => setMoreOpen(prev => !prev)}
+          aria-expanded={moreOpen}
+        >
+          More Filters {moreOpen ? '▲' : '▼'}
+        </button>
+
+        {hasActive && (
+          <button className="bfb-clear-btn" onClick={onClearFilters}>
             Clear All
           </button>
         )}
       </div>
 
-      <div className="filter-section">
-        <label htmlFor="search">Search</label>
-        <input
-          id="search"
-          type="text"
-          placeholder="Search beats..."
-          value={filters.search || ''}
-          onChange={(e) => updateFilter('search', e.target.value)}
-          className="search-input"
-        />
-      </div>
-
-      <div className="filter-section">
-        <label htmlFor="genre">Genre</label>
-        <select
-          id="genre"
-          value={filters.genre || ''}
-          onChange={(e) => updateFilter('genre', e.target.value || undefined)}
-          className="filter-select"
-        >
-          <option value="">All Genres</option>
-          {GENRES.map((genre) => (
-            <option key={genre} value={genre}>
-              {genre}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="filter-section">
-        <label htmlFor="key">Key</label>
-        <select
-          id="key"
-          value={filters.key || ''}
-          onChange={(e) => updateFilter('key', e.target.value || undefined)}
-          className="filter-select"
-        >
-          <option value="">All Keys</option>
-          {KEYS.map((key) => (
-            <option key={key} value={key}>
-              {key}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="filter-section">
-        <label>BPM Range</label>
-        <div className="bpm-range">
-          <div className="bpm-input-group">
-            <label htmlFor="bpm-min">Min</label>
-            <input
-              id="bpm-min"
-              type="number"
-              min={BPM_RANGES.min}
-              max={BPM_RANGES.max}
-              step={BPM_RANGES.step}
-              placeholder="60"
-              value={filters.bpmMin || ''}
-              onChange={(e) => updateFilter('bpmMin', e.target.value ? parseInt(e.target.value) : undefined)}
-              className="bpm-input"
-            />
+      {/* More Filters panel */}
+      {moreOpen && (
+        <div className="bfb-more-panel">
+          <div className="bfb-more-group">
+            <label htmlFor="bfb-key" className="bfb-label">Key</label>
+            <select
+              id="bfb-key"
+              className="bfb-select"
+              value={filters.key || ''}
+              onChange={e => onFiltersChange({ ...filters, key: e.target.value || undefined })}
+            >
+              <option value="">Any Key</option>
+              {['C','C#','D','D#','E','F','F#','G','G#','A','A#','B',
+                'Cm','C#m','Dm','D#m','Em','Fm','F#m','Gm','G#m','Am','A#m','Bm'].map(k => (
+                <option key={k} value={k}>{k}</option>
+              ))}
+            </select>
           </div>
-          <span className="bpm-separator">-</span>
-          <div className="bpm-input-group">
-            <label htmlFor="bpm-max">Max</label>
-            <input
-              id="bpm-max"
-              type="number"
-              min={BPM_RANGES.min}
-              max={BPM_RANGES.max}
-              step={BPM_RANGES.step}
-              placeholder="200"
-              value={filters.bpmMax || ''}
-              onChange={(e) => updateFilter('bpmMax', e.target.value ? parseInt(e.target.value) : undefined)}
-              className="bpm-input"
-            />
+          <div className="bfb-more-group bfb-bpm-group">
+            <span className="bfb-label">BPM Range</span>
+            <div className="bfb-bpm-inputs">
+              <input
+                type="number"
+                className="bfb-bpm-input"
+                min={60} max={200} step={5}
+                placeholder="Min"
+                value={filters.bpmMin || ''}
+                onChange={e => onFiltersChange({ ...filters, bpmMin: e.target.value ? parseInt(e.target.value) : undefined })}
+                aria-label="Minimum BPM"
+              />
+              <span className="bfb-bpm-sep">–</span>
+              <input
+                type="number"
+                className="bfb-bpm-input"
+                min={60} max={200} step={5}
+                placeholder="Max"
+                value={filters.bpmMax || ''}
+                onChange={e => onFiltersChange({ ...filters, bpmMax: e.target.value ? parseInt(e.target.value) : undefined })}
+                aria-label="Maximum BPM"
+              />
+            </div>
           </div>
         </div>
-      </div>
-
-
+      )}
     </div>
   );
 };

--- a/src/components/beats/BeatFilters.tsx
+++ b/src/components/beats/BeatFilters.tsx
@@ -120,7 +120,7 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
                 min={BPM_RANGES.min} max={BPM_RANGES.max} step={BPM_RANGES.step}
                 placeholder="Min"
                 value={filters.bpmMin || ''}
-                onChange={e => onFiltersChange({ ...filters, bpmMin: e.target.value ? parseInt(e.target.value) : undefined })}
+                onChange={e => { const v = parseInt(e.target.value); onFiltersChange({ ...filters, bpmMin: e.target.value && !isNaN(v) ? v : undefined }); }}
                 aria-label="Minimum BPM"
               />
               <span className="bfb-bpm-sep">–</span>
@@ -130,7 +130,7 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
                 min={BPM_RANGES.min} max={BPM_RANGES.max} step={BPM_RANGES.step}
                 placeholder="Max"
                 value={filters.bpmMax || ''}
-                onChange={e => onFiltersChange({ ...filters, bpmMax: e.target.value ? parseInt(e.target.value) : undefined })}
+                onChange={e => { const v = parseInt(e.target.value); onFiltersChange({ ...filters, bpmMax: e.target.value && !isNaN(v) ? v : undefined }); }}
                 aria-label="Maximum BPM"
               />
             </div>

--- a/src/components/beats/BeatFilters.tsx
+++ b/src/components/beats/BeatFilters.tsx
@@ -46,7 +46,9 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
       {/* Mood pills */}
       <div className="bfb-pills-row" role="group" aria-label="Filter by mood">
         <button
+          type="button"
           className={`bfb-pill${!filters.mood ? ' active' : ''}`}
+          aria-pressed={!filters.mood}
           onClick={() => setMood(undefined)}
         >
           All
@@ -54,7 +56,9 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
         {MOODS.map(mood => (
           <button
             key={mood}
+            type="button"
             className={`bfb-pill${filters.mood === mood ? ' active' : ''}`}
+            aria-pressed={filters.mood === mood}
             onClick={() => setMood(filters.mood === mood ? undefined : mood)}
           >
             {mood}

--- a/src/data/beats.json
+++ b/src/data/beats.json
@@ -5,224 +5,393 @@
       "title": "Bain",
       "bpm": 142,
       "key": "Am",
-      "genres": ["Drill", "Hip Hop"],
+      "genres": [
+        "Drill",
+        "Hip Hop"
+      ],
       "preview_path": "https://riqbeatstorebucket.s3.us-east-2.amazonaws.com/previews/bain_142_preview.mp3",
       "full_path": "https://riqbeatstorebucket.s3.us-east-2.amazonaws.com/full_tracks/6+-+bain+-+142+BPM.mp3",
       "cover_path": "/covers/cover001.png",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-01-15",
-      "tags": ["slizzy", "cash cobain", "sexy drill"]
+      "tags": [
+        "slizzy",
+        "cash cobain",
+        "sexy drill"
+      ],
+      "mood": [
+        "Dark",
+        "Aggressive"
+      ]
     },
     {
       "beat_id": "beat002",
       "title": "Mayze",
       "bpm": 126,
       "key": "Cm",
-      "genres": ["Hip Hop"],
+      "genres": [
+        "Hip Hop"
+      ],
       "preview_path": "https://riqbeatstorebucket.s3.us-east-2.amazonaws.com/previews/mayze_126_bpm.mp3",
       "full_path": "https://riqbeatstorebucket.s3.us-east-2.amazonaws.com/full_tracks/mayze_126_Cm_full.aif",
       "cover_path": "/covers/cover002.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-01-20",
-      "tags": ["brazilian", "trap", "chill"]
+      "tags": [
+        "brazilian",
+        "trap",
+        "chill"
+      ],
+      "mood": [
+        "Chill",
+        "Melodic"
+      ]
     },
     {
       "beat_id": "beat003",
       "title": "Midnight Soul",
       "bpm": 75,
       "key": "Dm",
-      "genres": ["R&B", "Soul"],
+      "genres": [
+        "R&B",
+        "Soul"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover003.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-01-25",
-      "tags": ["romantic", "smooth", "sultry"]
+      "tags": [
+        "romantic",
+        "smooth",
+        "sultry"
+      ],
+      "mood": [
+        "Emotional",
+        "Melodic"
+      ]
     },
     {
       "beat_id": "drill_001",
       "title": "Street Heat",
       "bpm": 150,
       "key": "F#m",
-      "genres": ["Drill", "Hip Hop"],
+      "genres": [
+        "Drill",
+        "Hip Hop"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover004.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-02-01",
-      "tags": ["aggressive", "hard", "street"]
+      "tags": [
+        "aggressive",
+        "hard",
+        "street"
+      ],
+      "mood": [
+        "Aggressive",
+        "Dark"
+      ]
     },
     {
       "beat_id": "afrobeats_001",
       "title": "Lagos Nights",
       "bpm": 105,
       "key": "C",
-      "genres": ["Afrobeats", "Pop"],
+      "genres": [
+        "Afrobeats",
+        "Pop"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover005.png",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-02-05",
-      "tags": ["rhythmic", "danceable", "afro"]
+      "tags": [
+        "rhythmic",
+        "danceable",
+        "afro"
+      ],
+      "mood": [
+        "Energetic",
+        "Happy"
+      ]
     },
     {
       "beat_id": "pop_001",
       "title": "Summer Dreams",
       "bpm": 120,
       "key": "E",
-      "genres": ["Pop"],
+      "genres": [
+        "Pop"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover006.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-02-10",
-      "tags": ["upbeat", "catchy", "radio"]
+      "tags": [
+        "upbeat",
+        "catchy",
+        "radio"
+      ],
+      "mood": [
+        "Happy",
+        "Energetic"
+      ]
     },
     {
       "beat_id": "trap_rnb_001",
       "title": "Velvet Trap",
       "bpm": 130,
       "key": "Bm",
-      "genres": ["Trap", "R&B"],
+      "genres": [
+        "Trap",
+        "R&B"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover007.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-02-15",
-      "tags": ["smooth", "melodic", "modern"]
+      "tags": [
+        "smooth",
+        "melodic",
+        "modern"
+      ],
+      "mood": [
+        "Melodic",
+        "Chill"
+      ]
     },
     {
       "beat_id": "drill_afro_001",
       "title": "Afro Drill",
       "bpm": 145,
       "key": "Em",
-      "genres": ["Drill", "Afrobeats"],
+      "genres": [
+        "Drill",
+        "Afrobeats"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover008.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-02-20",
-      "tags": ["fusion", "energetic", "cultural"]
+      "tags": [
+        "fusion",
+        "energetic",
+        "cultural"
+      ],
+      "mood": [
+        "Energetic",
+        "Aggressive"
+      ]
     },
     {
       "beat_id": "hiphop_002",
       "title": "Cold Winter",
       "bpm": 88,
       "key": "Gm",
-      "genres": ["Hip Hop"],
+      "genres": [
+        "Hip Hop"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover009.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-03-01",
-      "tags": ["dark", "atmospheric", "lyrical"]
+      "tags": [
+        "dark",
+        "atmospheric",
+        "lyrical"
+      ],
+      "mood": [
+        "Dark",
+        "Emotional"
+      ]
     },
     {
       "beat_id": "rnb_002",
       "title": "Golden Hour",
       "bpm": 95,
       "key": "A",
-      "genres": ["R&B", "Soul"],
+      "genres": [
+        "R&B",
+        "Soul"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover010.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-03-08",
-      "tags": ["warm", "soulful", "chill"]
+      "tags": [
+        "warm",
+        "soulful",
+        "chill"
+      ],
+      "mood": [
+        "Chill",
+        "Emotional"
+      ]
     },
     {
       "beat_id": "trap_002",
       "title": "Neon Pulse",
       "bpm": 140,
       "key": "C#m",
-      "genres": ["Trap"],
+      "genres": [
+        "Trap"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover001.png",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-03-15",
-      "tags": ["808s", "dark", "hard"]
+      "tags": [
+        "808s",
+        "dark",
+        "hard"
+      ],
+      "mood": [
+        "Dark",
+        "Aggressive"
+      ]
     },
     {
       "beat_id": "drill_002",
       "title": "Carbon",
       "bpm": 148,
       "key": "Dm",
-      "genres": ["Drill", "Hip Hop"],
+      "genres": [
+        "Drill",
+        "Hip Hop"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover002.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-03-22",
-      "tags": ["uk drill", "aggressive", "cinematic"]
+      "tags": [
+        "uk drill",
+        "aggressive",
+        "cinematic"
+      ],
+      "mood": [
+        "Aggressive",
+        "Dark"
+      ]
     },
     {
       "beat_id": "afrobeats_002",
       "title": "Accra",
       "bpm": 110,
       "key": "G",
-      "genres": ["Afrobeats"],
+      "genres": [
+        "Afrobeats"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover003.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-04-01",
-      "tags": ["afro", "vibrant", "danceable"]
+      "tags": [
+        "afro",
+        "vibrant",
+        "danceable"
+      ],
+      "mood": [
+        "Energetic",
+        "Happy"
+      ]
     },
     {
       "beat_id": "pop_002",
       "title": "Electric Feel",
       "bpm": 115,
       "key": "D",
-      "genres": ["Pop", "R&B"],
+      "genres": [
+        "Pop",
+        "R&B"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover004.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-04-08",
-      "tags": ["pop", "melodic", "radio-ready"]
+      "tags": [
+        "pop",
+        "melodic",
+        "radio-ready"
+      ],
+      "mood": [
+        "Melodic",
+        "Happy"
+      ]
     },
     {
       "beat_id": "hiphop_003",
       "title": "Blueprint",
       "bpm": 93,
       "key": "F",
-      "genres": ["Hip Hop"],
+      "genres": [
+        "Hip Hop"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover005.png",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-04-15",
-      "tags": ["boom bap", "classic"]
+      "tags": [
+        "boom bap",
+        "classic"
+      ],
+      "mood": [
+        "Chill",
+        "Melodic"
+      ]
     },
     {
       "beat_id": "trap_rnb_002",
       "title": "Rose Gold",
       "bpm": 135,
       "key": "G#m",
-      "genres": ["Trap", "R&B"],
+      "genres": [
+        "Trap",
+        "R&B"
+      ],
       "preview_path": "",
       "full_path": "",
       "cover_path": "/covers/cover006.jpg",
       "lease_price": 50,
       "exclusive_price": 200,
       "created_at": "2024-04-22",
-      "tags": ["romantic", "trap", "modern"]
+      "tags": [
+        "romantic",
+        "trap",
+        "modern"
+      ],
+      "mood": [
+        "Melodic",
+        "Emotional"
+      ]
     }
   ]
 }

--- a/src/pages/Beats.tsx
+++ b/src/pages/Beats.tsx
@@ -40,8 +40,9 @@ const Beats: React.FC = () => {
     }
 
     if (filters.mood) {
+      // Only apply mood filter to beats that have mood data; beats without it are shown
       filtered = filtered.filter(beat =>
-        beat.mood?.map(m => m.toLowerCase()).includes(filters.mood!.toLowerCase())
+        !beat.mood || beat.mood.map(m => m.toLowerCase()).includes(filters.mood!.toLowerCase())
       );
     }
 
@@ -53,11 +54,11 @@ const Beats: React.FC = () => {
       filtered = filtered.filter(beat => beat.key === filters.key);
     }
 
-    if (filters.bpmMin) {
+    if (filters.bpmMin !== undefined && !isNaN(filters.bpmMin)) {
       filtered = filtered.filter(beat => beat.bpm >= filters.bpmMin!);
     }
 
-    if (filters.bpmMax) {
+    if (filters.bpmMax !== undefined && !isNaN(filters.bpmMax)) {
       filtered = filtered.filter(beat => beat.bpm <= filters.bpmMax!);
     }
 

--- a/src/pages/Beats.tsx
+++ b/src/pages/Beats.tsx
@@ -40,9 +40,8 @@ const Beats: React.FC = () => {
     }
 
     if (filters.mood) {
-      // Only apply mood filter to beats that have mood data; beats without it are shown
       filtered = filtered.filter(beat =>
-        !beat.mood || beat.mood.map(m => m.toLowerCase()).includes(filters.mood!.toLowerCase())
+        beat.mood?.map(m => m.toLowerCase()).includes(filters.mood!.toLowerCase())
       );
     }
 

--- a/src/pages/Beats.tsx
+++ b/src/pages/Beats.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import usePageMeta from '../hooks/usePageMeta';
-import '../styles/PageContent.css';
 import '../styles/BeatsStyles.css';
 import BeatCard from '../components/beats/BeatCard';
 import EmailCapture from '../components/EmailCapture';
@@ -12,7 +11,7 @@ const Beats: React.FC = () => {
   const [beats, setBeats] = useState<Beat[]>([]);
   const [filteredBeats, setFilteredBeats] = useState<Beat[]>([]);
   const [filters, setFilters] = useState<BeatFiltersType>({});
-  const [currentlyPlaying, setCurrentlyPlaying] = useState<string | null>(null);
+  const [view, setView] = useState<'list' | 'grid'>('list');
   const [isLoading, setIsLoading] = useState(true);
 
   usePageMeta({
@@ -21,41 +20,43 @@ const Beats: React.FC = () => {
     canonicalPath: '/beats',
   });
 
-  // Load beats data
   useEffect(() => {
     setBeats(beatsData.beats);
     setFilteredBeats(beatsData.beats);
     setIsLoading(false);
   }, []);
 
-  // Apply filters
   useEffect(() => {
     let filtered = [...beats];
 
-    // Search filter
     if (filters.search) {
-      const searchTerm = filters.search.toLowerCase();
-      filtered = filtered.filter(beat => 
-        beat.title.toLowerCase().includes(searchTerm) ||
-        beat.genres.some(genre => genre.toLowerCase().includes(searchTerm)) ||
-        beat.tags?.some(tag => tag.toLowerCase().includes(searchTerm))
+      const q = filters.search.toLowerCase();
+      filtered = filtered.filter(beat =>
+        beat.title.toLowerCase().includes(q) ||
+        beat.genres.some(g => g.toLowerCase().includes(q)) ||
+        beat.tags?.some(t => t.toLowerCase().includes(q)) ||
+        beat.mood?.some(m => m.toLowerCase().includes(q))
       );
     }
 
-    // Genre filter
+    if (filters.mood) {
+      filtered = filtered.filter(beat =>
+        beat.mood?.map(m => m.toLowerCase()).includes(filters.mood!.toLowerCase())
+      );
+    }
+
     if (filters.genre) {
       filtered = filtered.filter(beat => beat.genres.includes(filters.genre!));
     }
 
-    // Key filter
     if (filters.key) {
       filtered = filtered.filter(beat => beat.key === filters.key);
     }
 
-    // BPM filters
     if (filters.bpmMin) {
       filtered = filtered.filter(beat => beat.bpm >= filters.bpmMin!);
     }
+
     if (filters.bpmMax) {
       filtered = filtered.filter(beat => beat.bpm <= filters.bpmMax!);
     }
@@ -63,90 +64,115 @@ const Beats: React.FC = () => {
     setFilteredBeats(filtered);
   }, [beats, filters]);
 
-  const handlePlay = (beatId: string) => {
-    setCurrentlyPlaying(beatId);
-  };
+  const handleFiltersChange = (newFilters: BeatFiltersType) => setFilters(newFilters);
+  const handleClearFilters = () => setFilters({});
 
-  const handlePause = () => {
-    setCurrentlyPlaying(null);
-  };
-
-  const handleFiltersChange = (newFilters: BeatFiltersType) => {
-    setFilters(newFilters);
-  };
-
-  const handleClearFilters = () => {
-    setFilters({});
-  };
+  const hasActiveFilters = Object.values(filters).some(v => v !== undefined && v !== '');
 
   if (isLoading) {
     return (
-      <div className="page-content">
-        <div className="loading-spinner">Loading beats...</div>
+      <div className="beats-page">
+        <div className="beats-loading">Loading beats…</div>
       </div>
     );
   }
 
   return (
-    <div className="page-content">
-      <div className="beats-header">
-        <h1>Beats</h1>
-        <p>High-quality instrumentals for your next project</p>
-        <div className="beats-stats">
-          <span>{beats.length} beats available</span>
-          <span>•</span>
-          <span>30-second previews</span>
-          <span>•</span>
-          <span>Instant download</span>
+    <div className="beats-page">
+      {/* Page header */}
+      <div className="beats-page-header">
+        <div className="beats-container">
+          <div className="beats-header-content">
+            <div>
+              <h1>Beat Store</h1>
+              <p className="beats-header-sub">
+                {beats.length} beats &nbsp;·&nbsp; Instant download &nbsp;·&nbsp; WAV quality
+              </p>
+            </div>
+            {/* View toggle */}
+            <div className="beats-view-toggle" role="group" aria-label="View mode">
+              <button
+                className={`vtoggle-btn${view === 'list' ? ' active' : ''}`}
+                onClick={() => setView('list')}
+                aria-pressed={view === 'list'}
+                title="List view"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <line x1="8" y1="6" x2="21" y2="6"/>
+                  <line x1="8" y1="12" x2="21" y2="12"/>
+                  <line x1="8" y1="18" x2="21" y2="18"/>
+                  <line x1="3" y1="6" x2="3.01" y2="6"/>
+                  <line x1="3" y1="12" x2="3.01" y2="12"/>
+                  <line x1="3" y1="18" x2="3.01" y2="18"/>
+                </svg>
+              </button>
+              <button
+                className={`vtoggle-btn${view === 'grid' ? ' active' : ''}`}
+                onClick={() => setView('grid')}
+                aria-pressed={view === 'grid'}
+                title="Grid view"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <rect x="3" y="3" width="7" height="7"/>
+                  <rect x="14" y="3" width="7" height="7"/>
+                  <rect x="3" y="14" width="7" height="7"/>
+                  <rect x="14" y="14" width="7" height="7"/>
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
-      
-      <div className="beats-layout">
-        <aside className="beats-sidebar">
-          <BeatFilters 
+
+      {/* Filters */}
+      <div className="beats-filters-section">
+        <div className="beats-container">
+          <BeatFilters
             filters={filters}
             onFiltersChange={handleFiltersChange}
             onClearFilters={handleClearFilters}
           />
-        </aside>
+        </div>
+      </div>
 
-        <main className="beats-main">
-          <div className="beats-results-header">
-            <h2>
-              {filteredBeats.length} beat{filteredBeats.length !== 1 ? 's' : ''} found
-            </h2>
-            {Object.keys(filters).some(key => filters[key as keyof BeatFiltersType] !== undefined && filters[key as keyof BeatFiltersType] !== '') && (
-              <button 
-                className="clear-all-filters"
-                onClick={handleClearFilters}
-              >
-                Clear all filters
-              </button>
-            )}
-          </div>
+      {/* Results */}
+      <div className="beats-results-section">
+        <div className="beats-container">
+          {hasActiveFilters && (
+            <p className="beats-results-count">
+              {filteredBeats.length} result{filteredBeats.length !== 1 ? 's' : ''}
+            </p>
+          )}
 
           {filteredBeats.length === 0 ? (
-            <div className="no-beats-found">
-              <h3>No beats found</h3>
-              <p>Try adjusting your filters or browse all beats.</p>
-              <button onClick={handleClearFilters}>Show all beats</button>
+            <div className="beats-empty">
+              <p>No beats match your filters.</p>
+              <button className="btn-secondary" onClick={handleClearFilters}>
+                Clear Filters
+              </button>
+            </div>
+          ) : view === 'list' ? (
+            <div className="beats-list">
+              {filteredBeats.map(beat => (
+                <BeatCard key={beat.beat_id} beat={beat} view="list" />
+              ))}
             </div>
           ) : (
             <div className="beats-grid">
-              {filteredBeats.map((beat) => (
-                <BeatCard
-                  key={beat.beat_id}
-                  beat={beat}
-                  isPlaying={currentlyPlaying === beat.beat_id}
-                  onPlay={handlePlay}
-                  onPause={handlePause}
-                />
+              {filteredBeats.map(beat => (
+                <BeatCard key={beat.beat_id} beat={beat} view="grid" />
               ))}
             </div>
           )}
-        </main>
+        </div>
       </div>
-      <EmailCapture />
+
+      {/* Email capture */}
+      <div className="beats-email-section">
+        <div className="beats-container">
+          <EmailCapture />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -20,21 +20,13 @@ const Success = () => {
     useEffect(() => {
         const params = new URLSearchParams(location.search);
         const stripeSessionId = params.get('session_id');
+        const consultationFlag = params.get('has_consultation');
 
-        if (stripeSessionId) {
-            setSessionId(stripeSessionId);
-            // Check if this order included a consultation service
-            // The backend webhook handles fulfillment; we just display confirmation here.
-            // If a consultation was purchased, the backend can set a query param or we
-            // can inspect the cart snapshot stored in sessionStorage before checkout.
-            const consultationFlag = params.get('has_consultation');
-            if (consultationFlag === '1') {
-                setHasConsultation(true);
-            }
-        }
-
+        // Reset all state so navigating to a different /success URL never shows stale data
+        setSessionId(stripeSessionId);
+        setHasConsultation(consultationFlag === '1');
         setLoading(false);
-    }, [location]);
+    }, [location.search]);
 
     if (loading) {
         return (

--- a/src/styles/AudioPlayer.css
+++ b/src/styles/AudioPlayer.css
@@ -1,0 +1,208 @@
+:root {
+  --audio-player-height: 72px;
+}
+
+.audio-player {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 90;
+  height: var(--audio-player-height);
+  background: var(--dark-taupe);
+  border-top: 1px solid rgba(232, 221, 211, 0.2);
+  box-shadow: 0 -4px 20px rgba(74, 63, 48, 0.3);
+}
+
+.audio-player-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+/* Track info */
+.ap-track-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 180px;
+  flex-shrink: 0;
+}
+
+.ap-cover {
+  width: 44px;
+  height: 44px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.ap-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.ap-title {
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--cream);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+
+.ap-detail {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--almond);
+  opacity: 0.7;
+}
+
+/* Controls */
+.ap-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.ap-play-btn {
+  background: var(--almond);
+  border: none;
+  color: var(--dark-taupe);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+  padding: 0;
+}
+
+.ap-play-btn:hover {
+  background: #FFFFFF;
+  transform: scale(1.06);
+  border: none;
+}
+
+.ap-play-btn:focus {
+  outline: 2px solid var(--tan);
+  outline-offset: 2px;
+}
+
+.ap-progress-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.ap-time {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--almond);
+  opacity: 0.8;
+  flex-shrink: 0;
+  min-width: 32px;
+  text-align: center;
+}
+
+.ap-progress-track {
+  position: relative;
+  flex: 1;
+  height: 4px;
+  background: rgba(232, 221, 211, 0.2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.ap-progress-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: var(--tan);
+  border-radius: 2px;
+  pointer-events: none;
+  transition: width 0.1s linear;
+}
+
+.ap-seek {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  -webkit-appearance: none;
+}
+
+/* Volume */
+.ap-volume {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--almond);
+  opacity: 0.8;
+  flex-shrink: 0;
+}
+
+.ap-volume-slider {
+  width: 72px;
+  height: 3px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: rgba(232, 221, 211, 0.25);
+  border-radius: 2px;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+.ap-volume-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--almond);
+  cursor: pointer;
+  border: none;
+}
+
+/* Mobile */
+@media (max-width: 640px) {
+  .audio-player-inner {
+    padding: 0.625rem 1rem;
+    gap: 0.875rem;
+  }
+
+  .ap-track-info {
+    min-width: 0;
+  }
+
+  .ap-title {
+    max-width: 100px;
+    font-size: 0.8125rem;
+  }
+
+  .ap-volume {
+    display: none;
+  }
+}

--- a/src/styles/AudioPlayer.css
+++ b/src/styles/AudioPlayer.css
@@ -125,7 +125,7 @@
   height: 4px;
   background: rgba(232, 221, 211, 0.2);
   border-radius: 2px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .ap-progress-fill {
@@ -141,10 +141,11 @@
 
 .ap-seek {
   position: absolute;
-  top: 0;
+  top: 50%;
   left: 0;
+  transform: translateY(-50%);
   width: 100%;
-  height: 100%;
+  height: 16px; /* larger hit area */
   opacity: 0;
   cursor: pointer;
   margin: 0;
@@ -152,6 +153,18 @@
   border: none;
   background: transparent;
   -webkit-appearance: none;
+}
+
+/* Show a visible ring on the track when the seek input is focused */
+.ap-seek:focus-visible ~ .ap-progress-fill,
+.ap-seek:focus-visible {
+  outline: none;
+}
+
+.ap-progress-track:has(.ap-seek:focus-visible) {
+  outline: 2px solid var(--tan);
+  outline-offset: 3px;
+  border-radius: 2px;
 }
 
 /* Volume */

--- a/src/styles/BeatsStyles.css
+++ b/src/styles/BeatsStyles.css
@@ -1,550 +1,611 @@
-/* Beats Page Styles */
-
-.beats-header {
-  text-align: center;
-  margin-bottom: 3rem;
-  padding: 2rem 0;
+.beats-page {
+  width: 100%;
+  background-color: var(--bg-primary);
 }
 
-.beats-header h1 {
-  font-size: 3rem;
-  margin-bottom: 1rem;
-  background: linear-gradient(135deg, var(--text-dark), var(--text-medium));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+.beats-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* ─── Page Header ────────────────────────────────────── */
+.beats-page-header {
+  background-color: var(--bg-primary);
+  padding: 3rem 0 1.5rem;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.beats-header-content {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.beats-page-header h1 {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
   font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 0.375rem;
 }
 
-.beats-header p {
-  font-size: 1.2rem;
-  color: var(--text-medium);
+.beats-header-sub {
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.beats-loading {
+  padding: 6rem 2rem;
+  text-align: center;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+}
+
+/* ─── View Toggle ────────────────────────────────────── */
+.beats-view-toggle {
+  display: flex;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.vtoggle-btn {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: var(--text-muted);
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.vtoggle-btn:hover {
+  background: var(--accent-glow);
+  color: var(--accent-primary);
+  transform: none;
+}
+
+.vtoggle-btn.active {
+  background: var(--accent-primary);
+  color: #FFFFFF;
+}
+
+.vtoggle-btn + .vtoggle-btn {
+  border-left: 1px solid var(--border-default);
+}
+
+/* ─── Filters Bar ────────────────────────────────────── */
+.beats-filters-section {
+  padding: 1.5rem 0 0;
+  background-color: var(--bg-primary);
+}
+
+.beat-filters-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bfb-search-wrap {
+  position: relative;
+  max-width: 360px;
+}
+
+.bfb-search-icon {
+  position: absolute;
+  left: 0.875rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.bfb-search {
+  width: 100%;
+  padding: 0.625rem 1rem 0.625rem 2.5rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 0.9375rem;
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  transition: border-color var(--transition-default), box-shadow var(--transition-default);
+}
+
+.bfb-search:focus {
+  outline: none;
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+/* Pills */
+.bfb-pills-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.bfb-pill {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  padding: 0.375rem 0.875rem;
+  border-radius: 50px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.bfb-pill:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  background: var(--accent-glow);
+  transform: none;
+}
+
+.bfb-pill.active {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: #FFFFFF;
+}
+
+/* Bottom row */
+.bfb-bottom-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.bfb-label {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.75px;
+  margin-bottom: 0.375rem;
+  display: block;
+}
+
+.bfb-genre-wrap {
+  display: flex;
+  flex-direction: column;
+}
+
+.bfb-select {
+  padding: 0.5rem 2rem 0.5rem 0.875rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-family: var(--font-body);
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L6 7L11 1' stroke='%238B7355' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  width: 160px;
+}
+
+.bfb-select:focus {
+  outline: none;
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.bfb-more-btn {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  padding: 0.5rem 0.875rem;
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  align-self: flex-end;
+}
+
+.bfb-more-btn:hover, .bfb-more-btn.open {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  background: var(--accent-glow);
+  transform: none;
+}
+
+.bfb-clear-btn {
+  background: transparent;
+  border: 1px solid var(--error);
+  color: var(--error);
+  padding: 0.5rem 0.875rem;
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  align-self: flex-end;
+}
+
+.bfb-clear-btn:hover {
+  background: rgba(184, 92, 92, 0.08);
+  transform: none;
+}
+
+.bfb-more-panel {
+  display: flex;
+  gap: 2rem;
+  padding: 1.25rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  flex-wrap: wrap;
+}
+
+.bfb-more-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.bfb-bpm-inputs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bfb-bpm-input {
+  width: 80px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.bfb-bpm-sep {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+/* ─── Results ────────────────────────────────────────── */
+.beats-results-section {
+  padding: 1.5rem 0 3rem;
+}
+
+.beats-results-count {
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
   margin-bottom: 1rem;
 }
 
-.beats-stats {
+.beats-empty {
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.beats-empty p {
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+}
+
+/* ─── List View ──────────────────────────────────────── */
+.beats-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--bg-elevated);
+}
+
+.beat-card-list {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 1.25rem;
+  border-bottom: 1px solid var(--border-default);
+  transition: background var(--transition-fast);
+  position: relative;
+}
+
+.beat-card-list:last-child {
+  border-bottom: none;
+}
+
+.beat-card-list:hover,
+.beat-card-list.is-playing {
+  background: var(--accent-glow);
+}
+
+.bcl-play-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  border: none;
+  color: #FFFFFF;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  font-size: 0.9rem;
-  color: var(--text-dark);
-  font-weight: 600;
-}
-
-.beats-layout {
-  display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 2rem;
-  max-width: 1400px;
-  margin: 0 auto;
-}
-
-/* Sidebar Filters */
-.beats-sidebar {
-  position: sticky;
-  top: 2rem;
-  height: fit-content;
-}
-
-.beat-filters {
-  background: var(--color-neutral-1);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  border: 2px solid var(--color-neutral-3);
-  box-shadow: 0 4px 12px rgba(45, 45, 45, 0.1);
-}
-
-.filters-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.5rem;
-}
-
-.filters-header h3 {
-  color: var(--text-dark);
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 700;
-}
-
-.clear-filters-btn {
-  background: var(--color-neutral-2);
-  border: 2px solid var(--color-neutral-3);
-  color: var(--text-dark);
-  padding: 0.4rem 0.8rem;
-  border-radius: 0.5rem;
-  font-size: 0.8rem;
   cursor: pointer;
-  transition: all 0.3s ease;
-  font-weight: 600;
+  flex-shrink: 0;
+  transition: all var(--transition-fast);
+  padding: 0;
 }
 
-.clear-filters-btn:hover {
-  background: var(--color-accent-3);
-  border-color: var(--color-accent-3);
-  transform: translateY(-1px);
-}
-
-.filter-section {
-  margin-bottom: 1.5rem;
-}
-
-.filter-section label {
-  display: block;
-  color: var(--text-dark);
-  margin-bottom: 0.5rem;
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-.search-input, .filter-select {
-  width: 100%;
-  padding: 0.8rem;
-  background: var(--color-light);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 0.5rem;
-  color: var(--text-dark);
-  font-size: 0.9rem;
-  font-weight: 500;
-}
-
-.search-input:focus, .filter-select:focus {
-  border-color: var(--color-accent-3);
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(254, 200, 154, 0.2);
-}
-
-.search-input::placeholder {
-  color: var(--text-light);
-}
-
-.filter-select option {
-  background: var(--color-neutral-1);
-  color: var(--text-dark);
-}
-
-.bpm-range {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.bpm-input-group {
-  flex: 1;
-}
-
-.bpm-input-group label {
-  font-size: 0.8rem;
-  margin-bottom: 0.3rem;
-  font-weight: 600;
-}
-
-.bpm-input {
-  width: 100%;
-  padding: 0.6rem;
-  background: var(--color-light);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 0.5rem;
-  color: var(--text-dark);
-  font-size: 0.9rem;
-  font-weight: 500;
-}
-
-.bpm-input:focus {
-  border-color: var(--color-accent-3);
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(254, 200, 154, 0.2);
-}
-
-.bpm-separator {
-  color: var(--text-medium);
-  font-weight: bold;
-}
-
-
-
-/* Main Content */
-.beats-main {
-  min-height: 100vh;
-}
-
-.beats-results-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
-}
-
-.beats-results-header h2 {
-  color: var(--text-dark);
-  margin: 0;
-  font-size: 1.3rem;
-  font-weight: 700;
-}
-
-.clear-all-filters {
-  background: var(--color-neutral-2);
-  border: 2px solid var(--color-neutral-3);
-  color: var(--text-dark);
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-weight: 600;
-}
-
-.clear-all-filters:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-1px);
-}
-
-.beats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 2rem;
-}
-
-/* Beat Card */
-.beat-card {
-  background: var(--color-neutral-1);
-  border-radius: 1rem;
-  overflow: hidden;
-  border: 2px solid var(--color-neutral-3);
-  transition: all 0.3s ease;
-  cursor: pointer;
-  box-shadow: 0 4px 12px rgba(45, 45, 45, 0.1);
-}
-
-.beat-card:hover {
-  transform: translateY(-5px);
-  border-color: var(--color-accent-3);
-  box-shadow: 0 8px 24px rgba(45, 45, 45, 0.15);
-}
-
-.beat-cover {
-  position: relative;
-  aspect-ratio: 1;
-  overflow: hidden;
-}
-
-.beat-cover img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.3s ease;
-}
-
-.beat-card:hover .beat-cover img {
+.bcl-play-btn:hover {
+  background: var(--accent-hover);
   transform: scale(1.05);
 }
 
-.play-overlay {
+.bcl-play-btn:disabled {
+  background: var(--border-default);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  transform: none;
+}
+
+.bcl-cover {
+  width: 44px;
+  height: 44px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.bcl-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.bcl-title {
+  display: block;
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-heading);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 0.25rem;
+}
+
+.bcl-tags {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.bcl-tag {
+  font-size: 0.6875rem;
+  font-family: var(--font-body);
+  color: var(--text-secondary);
+  background: var(--almond);
+  padding: 0.125rem 0.5rem;
+  border-radius: 50px;
+}
+
+.bcl-tag-mood {
+  background: var(--pale-oak);
+  color: var(--stone);
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.bcl-meta {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-shrink: 0;
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.bcl-bpm { font-weight: 600; color: var(--text-primary); }
+
+/* ─── Buy Buttons ────────────────────────────────────── */
+.beat-buy-btns {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.beat-btn-lease {
+  background: transparent;
+  border: 1.5px solid var(--accent-primary);
+  color: var(--accent-primary);
+  padding: 0.4375rem 0.875rem;
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.beat-btn-lease:hover {
+  background: var(--accent-primary);
+  color: #FFFFFF;
+  transform: translateY(-1px);
+}
+
+.beat-btn-exclusive {
+  background: var(--accent-primary);
+  border: 1.5px solid var(--accent-primary);
+  color: #FFFFFF;
+  padding: 0.4375rem 0.875rem;
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all var(--transition-fast);
+}
+
+.beat-btn-exclusive:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+/* ─── Grid View ──────────────────────────────────────── */
+.beats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.beat-card-grid {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-default), transform var(--transition-default);
+}
+
+.beat-card-grid:hover,
+.beat-card-grid.is-playing {
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-2px);
+}
+
+.bcg-cover {
+  position: relative;
+  aspect-ratio: 1;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.bcg-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--transition-slow);
+}
+
+.beat-card-grid:hover .bcg-cover img {
+  transform: scale(1.04);
+}
+
+.bcg-play-overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(45, 45, 45, 0.6);
+  inset: 0;
+  background: rgba(74, 63, 48, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--transition-fast);
 }
 
-.beat-card:hover .play-overlay,
-.play-overlay:has(.play-btn.playing) {
+.beat-card-grid:hover .bcg-play-overlay,
+.beat-card-grid.is-playing .bcg-play-overlay {
   opacity: 1;
 }
 
-.play-btn {
-  background: var(--color-accent-3);
-  border: 2px solid var(--color-accent-3);
-  border-radius: 50%;
-  width: 60px;
-  height: 60px;
+.bcg-info {
+  padding: 1rem;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-size: 1.2rem;
-  color: var(--text-dark);
-  font-weight: 700;
-}
-
-.play-btn:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: scale(1.1);
-}
-
-.play-btn.playing {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  color: var(--text-dark);
-}
-
-.loading-spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--color-neutral-3);
-  border-top: 2px solid var(--color-accent-3);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-.no-preview-label {
-  font-size: 0.7rem;
-  color: var(--text-medium);
-  background: rgba(0, 0, 0, 0.55);
-  padding: 0.3rem 0.6rem;
-  border-radius: 0.4rem;
-  letter-spacing: 0.03em;
-  pointer-events: none;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
-.progress-bar {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: rgba(45, 45, 45, 0.3);
-}
-
-.progress-fill {
-  height: 100%;
-  background: var(--color-accent-3);
-  transition: width 0.1s ease;
-}
-
-.time-display {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  background: rgba(45, 45, 45, 0.8);
-  color: var(--color-neutral-1);
-  padding: 0.3rem 0.6rem;
-  border-radius: 1rem;
-  font-size: 0.7rem;
-  font-weight: 600;
-  border: 1px solid var(--color-neutral-3);
-}
-
-.beat-info {
-  padding: 1.5rem;
-}
-
-.beat-title {
-  color: var(--text-dark);
-  margin: 0 0 1rem 0;
-  font-size: 1.2rem;
-  font-weight: 700;
-}
-
-.beat-metadata {
-  display: flex;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  flex-wrap: wrap;
-}
-
-.beat-bpm, .beat-key, .beat-genre {
-  background: var(--color-accent-3);
-  color: var(--text-dark);
-  padding: 0.3rem 0.6rem;
-  border-radius: 1rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  border: 1px solid var(--color-accent-3);
-}
-
-.beat-tags {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
-  flex-wrap: wrap;
-}
-
-.beat-tag {
-  background: var(--color-light);
-  color: var(--text-medium);
-  padding: 0.2rem 0.5rem;
-  border-radius: 0.8rem;
-  font-size: 0.7rem;
-  font-weight: 500;
-  border: 1px solid var(--color-neutral-3);
-}
-
-.beat-pricing {
-  display: flex;
-  gap: 0.8rem;
   flex-direction: column;
+  gap: 0.5rem;
 }
 
-.lease-btn, .exclusive-btn {
-  flex: 1;
-  padding: 0.8rem;
-  border-radius: 0.5rem;
-  border: 2px solid;
-  cursor: pointer;
-  font-weight: 700;
-  transition: all 0.3s ease;
-}
-
-.lease-btn {
-  background: var(--color-accent-3);
-  color: var(--text-dark);
-  border-color: var(--color-accent-3);
-}
-
-.lease-btn:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(45, 45, 45, 0.2);
-}
-
-.exclusive-btn {
-  background: var(--color-light-2);
-  color: var(--text-dark);
-  border-color: var(--color-light-2);
-}
-
-.exclusive-btn:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(45, 45, 45, 0.2);
-}
-
-/* No Beats Found */
-.no-beats-found {
-  text-align: center;
-  padding: 4rem 2rem;
-  color: var(--text-medium);
-}
-
-.no-beats-found h3 {
-  color: var(--text-dark);
-  margin-bottom: 1rem;
-  font-weight: 700;
-}
-
-.no-beats-found button {
-  background: var(--color-accent-3);
-  color: var(--text-dark);
-  border: 2px solid var(--color-accent-3);
-  padding: 1rem 2rem;
-  border-radius: 0.5rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  margin-top: 1rem;
-}
-
-.no-beats-found button:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-2px);
-}
-
-/* Loading */
-.loading-spinner {
-  text-align: center;
-  padding: 4rem;
-  color: var(--text-dark);
-  font-size: 1.2rem;
+.bcg-title {
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
   font-weight: 600;
+  color: var(--text-heading);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-/* Responsive Design */
-@media (max-width: 1024px) {
-  .beats-layout {
-    grid-template-columns: 1fr;
-  }
-  
-  .beats-sidebar {
-    position: static;
-    order: 2;
-  }
-  
-  .beats-main {
-    order: 1;
+.bcg-meta {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+/* ─── Email section ──────────────────────────────────── */
+.beats-email-section {
+  background-color: var(--almond);
+  padding: 4rem 0;
+}
+
+/* ─── Responsive ─────────────────────────────────────── */
+@media (max-width: 900px) {
+  .beats-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (max-width: 768px) {
+  .beats-page-header {
+    padding: 2rem 0 1rem;
+  }
+
+  .bcl-meta {
+    display: none;
+  }
+
+  .bfb-pills-row {
+    gap: 0.375rem;
+  }
+}
+
+@media (max-width: 640px) {
   .beats-grid {
     grid-template-columns: 1fr;
   }
-  
-  .beats-results-header {
+
+  .beats-header-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .beat-buy-btns {
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .beat-btn-lease,
+  .beat-btn-exclusive {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+  }
+
+  .bcl-cover {
+    display: none;
+  }
+
+  .bfb-more-panel {
     flex-direction: column;
     gap: 1rem;
-    align-items: stretch;
   }
-  
-  .beat-metadata {
-    justify-content: center;
-  }
-  
-  .beat-pricing {
-    flex-direction: row;
-  }
-}
-
-@media (max-width: 480px) {
-  .beats-header h1 {
-    font-size: 2rem;
-  }
-  
-  .beats-stats {
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  
-  .beat-info {
-    padding: 1rem;
-  }
-}
-
-/* High contrast mode support */
-@media (prefers-contrast: high) {
-  .beat-filters,
-  .beat-card {
-    border-width: 3px;
-  }
-  
-  .search-input,
-  .filter-select,
-  .bpm-input,
-  .quick-filter-btn,
-  .lease-btn,
-  .exclusive-btn {
-    border-width: 3px;
-  }
-}
-
-/* Focus styles for accessibility */
-.search-input:focus,
-.filter-select:focus,
-.bpm-input:focus,
-.quick-filter-btn:focus,
-.clear-filters-btn:focus,
-.clear-all-filters:focus,
-.lease-btn:focus,
-.exclusive-btn:focus,
-.play-btn:focus {
-  outline: 3px solid var(--color-accent-3);
-  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- **Beat Store layout**: Full-width header, horizontal filter bar, list/grid view toggle
- **List view** (default): Rows with play button, cover thumbnail, title, mood tags, BPM/Key/Genre metadata, Lease + Exclusive buttons
- **Grid view**: 3-col cards with large cover art, hover play overlay, buy buttons below
- **BeatFilters**: Horizontal mood pills (Dark/Chill/Energetic/Smooth/Hard/Melodic/Aggressive/Emotional), search input, genre dropdown, collapsible "More Filters" (key + BPM range); sidebar layout removed
- **Persistent Audio Player**: Fixed bottom bar with cover, title, play/pause, seek, time, volume — lives in App.tsx outside Routes so it persists across page navigation
- **AudioPlayerContext**: Global React context manages currently playing beat state

## Test plan
- [ ] Build passes clean
- [ ] Beat list renders in list view by default
- [ ] Clicking play on a beat shows the bottom audio player bar
- [ ] Player persists when navigating to other pages
- [ ] Grid view toggle switches to 3-col card layout
- [ ] Mood pills filter beats by mood tag
- [ ] "More Filters" panel opens/closes
- [ ] Lease button adds to cart and opens drawer
- [ ] Exclusive button adds to cart and opens drawer
- [ ] Mobile (390px): buy buttons stack, list view still usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)