### PR TITLE
[Phase F] Redesign About, FeaturedWork, and Success pages — warm neutral palette

### DIFF
--- a/server.js
+++ b/server.js
@@ -152,11 +152,15 @@ app.post('/create-checkout-session', async (req, res) => {
       }
     }
 
+    const hasConsultation = items.some(
+      item => item.type === 'service' && item.service_id === 'artist_consultation'
+    );
+
     const sessionParams = {
       payment_method_types: ['card'],
       line_items: lineItems,
       mode: 'payment',
-      success_url: `${baseUrl}/success?session_id={CHECKOUT_SESSION_ID}`,
+      success_url: `${baseUrl}/success?session_id={CHECKOUT_SESSION_ID}${hasConsultation ? '&has_consultation=1' : ''}`,
       cancel_url: `${baseUrl}/beats`,
     };
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -3,121 +3,92 @@ import '../styles/PageContent.css';
 import '../styles/About.css';
 
 const About = () => {
-    usePageMeta({
-        title: 'About | PRODBYRIQ',
-        description: 'RIQ is a professional music producer and mix engineer. Learn about the experience and credits behind PRODBYRIQ.',
-        canonicalPath: '/about',
-    });
-    return (
-        <div className="page-content">
-            <div className="about-hero">
-                <div className="about-content">
-                    <h1>About RIQ</h1>
-                    <p className="about-subtitle">Music Producer, Audio Engineer &amp; Creative Visionary</p>
-                </div>
-            </div>
+  usePageMeta({
+    title: 'About | PRODBYRIQ',
+    description: 'RIQ is a professional music producer and mix engineer. Learn about the experience and credits behind PRODBYRIQ.',
+    canonicalPath: '/about',
+  });
 
-            {/* Producer Photo + Bio */}
-            <div className="about-photo-section">
-                <div className="about-photo-wrapper">
-                    {/* Replace /producer-photo.jpg with the real asset path when available */}
-                    <div className="about-photo-placeholder" role="img" aria-label="Producer photo">
-                        <span className="about-photo-initials" aria-hidden="true">RIQ</span>
-                    </div>
-                </div>
-                <div className="about-photo-bio">
-                    <h2>Tariq Georges</h2>
-                    <p className="about-photo-role">Producer · Mix Engineer · Pianist</p>
-                    <p>
-                        Tariq Georges is a multi-faceted musician trained in classical piano since age 4.
-                        A self-taught producer and audio engineer, he built his craft during 2020 and now
-                        works with artists from Boston, London, and beyond to deliver industry-grade records.
-                    </p>
-                </div>
-            </div>
+  return (
+    <div className="page-content ab-page">
 
-            <div className="about-sections">
-                <div className="about-section">
-                    <h2>My Story</h2>
-                    <p>
-                        Tariq Georges is a multi-faceted musician who was trained in classical music.
-                        He has been playing the piano since the age of 4 and is a self-taught producer and audio engineer.
-                        He started making beats in 2020 when COVID-19 hit and used that time to develop his skills
-                        as a producer and engineer. He now works with artists from Boston, London, and beyond
-                        to make beautiful tracks.
-                    </p>
-                </div>
-
-                {/* Credits */}
-                <div className="about-section">
-                    <h2>Credits</h2>
-                    <p className="about-credits-intro">Selected production, mixing, and mastering work.</p>
-                    <ul className="about-credits-list">
-                        {/* Replace these placeholders with real credits */}
-                        <li className="about-credit-item">
-                            <span className="about-credit-title">Credit Title &mdash; Artist Name</span>
-                            <span className="about-credit-role">Produced by RIQ</span>
-                        </li>
-                        <li className="about-credit-item">
-                            <span className="about-credit-title">Credit Title &mdash; Artist Name</span>
-                            <span className="about-credit-role">Mixed &amp; Mastered by RIQ</span>
-                        </li>
-                        <li className="about-credit-item">
-                            <span className="about-credit-title">Credit Title &mdash; Artist Name</span>
-                            <span className="about-credit-role">Mixed by RIQ</span>
-                        </li>
-                    </ul>
-                </div>
-
-                <div className="about-section">
-                    <h2>What I Do</h2>
-                    <div className="services-list">
-                        <div className="service-item">
-                            <h3>Music Production</h3>
-                            <p>Complete song production from initial concept to final arrangement</p>
-                        </div>
-                        <div className="service-item">
-                            <h3>Beat Making</h3>
-                            <p>Custom beat creation for any genre!</p>
-                        </div>
-                        <div className="service-item">
-                            <h3>Mixing</h3>
-                            <p>Professional mixing services to polish your recordings to industry standards.</p>
-                        </div>
-                        <div className="service-item">
-                            <h3>Mastering</h3>
-                            <p>Final mastering to ensure your tracks are leveled across all streaming services.</p>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="about-section">
-                    <h2>My Approach</h2>
-                    <p>
-                        Every project is unique, and I believe in working closely with each artist to understand
-                        their vision and goals. Whether you&apos;re looking for a specific sound or want to explore
-                        new creative territories, I&apos;m here to guide you through the process.
-                    </p>
-                </div>
-
-                {/* Testimonials */}
-                <div className="about-section">
-                    <h2>What Artists Say</h2>
-                    <div className="about-testimonials">
-                        {/* Replace placeholder quotes with real client reviews */}
-                        <blockquote className="about-testimonial">
-                            <p>&ldquo;Testimonial quote goes here &mdash; replace with a real client review.&rdquo;</p>
-                            <cite>&mdash; Artist Name</cite>
-                        </blockquote>
-                        <blockquote className="about-testimonial">
-                            <p>&ldquo;Second testimonial quote goes here &mdash; replace with a real client review.&rdquo;</p>
-                            <cite>&mdash; Artist Name</cite>
-                        </blockquote>
-                    </div>
-                </div>
-            </div>
+      {/* ── Hero ─────────────────────────────────────────────── */}
+      <section className="ab-hero">
+        <div className="ab-container">
+          <p className="ab-eyebrow">Producer · Mix Engineer · Pianist</p>
+          <h1>About RIQ</h1>
+          <p className="ab-hero-sub">
+            Making music that moves people — remotely, from scratch, at any distance.
+          </p>
         </div>
-    );
+      </section>
+
+      {/* ── Bio ──────────────────────────────────────────────── */}
+      <section className="ab-bio-section">
+        <div className="ab-container ab-bio-grid">
+          <div className="ab-photo-wrap">
+            <div className="ab-photo-placeholder" role="img" aria-label="Producer photo">
+              <span className="ab-photo-initials" aria-hidden="true">RIQ</span>
+            </div>
+          </div>
+          <div className="ab-bio-body">
+            <h2>Tariq Georges</h2>
+            <p className="ab-bio-role">Producer · Mix Engineer · Pianist</p>
+            <p>
+              Tariq Georges is a multi-faceted musician trained in classical piano since age 4.
+              A self-taught producer and audio engineer, he built his craft during 2020 and now
+              works with artists from Boston, London, and beyond to deliver industry-grade records.
+            </p>
+            <p>
+              Every project starts with the music — not the template. Whether it&apos;s a beat from
+              scratch or stems that need a final mix, the goal is the same: a record you&apos;re proud
+              to put out.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Credits ──────────────────────────────────────────── */}
+      <section className="ab-credits-section" aria-labelledby="ab-credits-heading">
+        <div className="ab-container">
+          <h2 id="ab-credits-heading">Credits</h2>
+          <p className="ab-section-sub">Selected production, mixing, and mastering work.</p>
+          <ul className="ab-credits-list">
+            <li className="ab-credit-item">
+              <span className="ab-credit-title">Credit Title &mdash; Artist Name</span>
+              <span className="ab-credit-role">Produced by RIQ</span>
+            </li>
+            <li className="ab-credit-item">
+              <span className="ab-credit-title">Credit Title &mdash; Artist Name</span>
+              <span className="ab-credit-role">Mixed &amp; Mastered by RIQ</span>
+            </li>
+            <li className="ab-credit-item">
+              <span className="ab-credit-title">Credit Title &mdash; Artist Name</span>
+              <span className="ab-credit-role">Mixed by RIQ</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* ── Testimonials ─────────────────────────────────────── */}
+      <section className="ab-testimonials-section" aria-labelledby="ab-testimonials-heading">
+        <div className="ab-container">
+          <h2 id="ab-testimonials-heading">What Artists Say</h2>
+          <div className="ab-testimonials-grid">
+            <blockquote className="ab-testimonial">
+              <p>&ldquo;Testimonial quote goes here &mdash; replace with a real client review.&rdquo;</p>
+              <cite>&mdash; Artist Name</cite>
+            </blockquote>
+            <blockquote className="ab-testimonial">
+              <p>&ldquo;Second testimonial quote goes here &mdash; replace with a real client review.&rdquo;</p>
+              <cite>&mdash; Artist Name</cite>
+            </blockquote>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  );
 };
 
 export default About;

--- a/src/pages/FeaturedWork.tsx
+++ b/src/pages/FeaturedWork.tsx
@@ -5,163 +5,158 @@ import '../styles/PageContent.css';
 import '../styles/FeaturedWork.css';
 
 interface Track {
-    id: string;
-    title: string;
-    platform: 'spotify' | 'soundcloud';
-    embedCode: string;
-    url: string;
-    description?: string;
+  id: string;
+  title: string;
+  platform: 'spotify' | 'soundcloud';
+  embedCode: string;
+  url: string;
+  description?: string;
 }
 
+const TRACKS: Track[] = [
+  {
+    id: '1',
+    title: 'Track 1',
+    platform: 'spotify',
+    embedCode: `<iframe src="https://open.spotify.com/embed/track/3rlbQrNDUyIpF5QPjpFCkV?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
+    url: 'https://open.spotify.com/track/3rlbQrNDUyIpF5QPjpFCkV',
+    description: 'Mixed & Mastered by RIQ',
+  },
+  {
+    id: '2',
+    title: 'Track 2',
+    platform: 'spotify',
+    embedCode: `<iframe src="https://open.spotify.com/embed/track/2hNLyPN3fM0Ds7LASznUkX?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
+    url: 'https://open.spotify.com/track/2hNLyPN3fM0Ds7LASznUkX',
+    description: 'Mixed & Mastered by RIQ',
+  },
+  {
+    id: '3',
+    title: 'Track 3',
+    platform: 'spotify',
+    embedCode: `<iframe src="https://open.spotify.com/embed/track/7ngZ2kMSW18SHZ7RG3QeOG?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
+    url: 'https://open.spotify.com/track/7ngZ2kMSW18SHZ7RG3QeOG',
+    description: 'Produced by RIQ',
+  },
+  {
+    id: '4',
+    title: 'mvp w/ j dean + sophia [OUT ON ALL PLATS]',
+    platform: 'soundcloud',
+    embedCode: `<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2065978932&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>`,
+    url: 'https://soundcloud.com/prodbyriq/mvp-w-j-dean-sophia?si=c61117b0c94148f4a442668189746841&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing',
+    description: 'Collaborative track featuring J Dean and Sophia',
+  },
+];
+
+type FilterValue = 'all' | 'spotify' | 'soundcloud';
+
 const FeaturedWork = () => {
-    usePageMeta({
-        title: 'Featured Work | PRODBYRIQ',
-        description: 'Hear mixes, masters, and productions by RIQ — hip hop, drill, R&B, and more.',
-        canonicalPath: '/featured-work',
-    });
-    const [filter, setFilter] = useState<'all' | 'spotify' | 'soundcloud'>('all');
+  usePageMeta({
+    title: 'Featured Work | PRODBYRIQ',
+    description: 'Hear mixes, masters, and productions by RIQ — hip hop, drill, R&B, and more.',
+    canonicalPath: '/featured-work',
+  });
 
-    // Sample tracks - you can easily add more here
-    const tracks: Track[] = [
-        {
-            id: '1',
-            title: 'Track 1',
-            platform: 'spotify',
-            embedCode: `<iframe src="https://open.spotify.com/embed/track/3rlbQrNDUyIpF5QPjpFCkV?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
-            url: 'https://open.spotify.com/track/3rlbQrNDUyIpF5QPjpFCkV',
-            description: 'Mixed & Mastered by RIQ'
-        },
-        {
-            id: '2',
-            title: 'Track 2',
-            platform: 'spotify',
-            embedCode: `<iframe src="https://open.spotify.com/embed/track/2hNLyPN3fM0Ds7LASznUkX?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
-            url: 'https://open.spotify.com/track/2hNLyPN3fM0Ds7LASznUkX',
-            description: 'Mixed & Mastered by RIQ'
-        },
-        {
-            id: '3',
-            title: 'Track 3',
-            platform: 'spotify',
-            embedCode: `<iframe src="https://open.spotify.com/embed/track/7ngZ2kMSW18SHZ7RG3QeOG?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
-            url: 'https://open.spotify.com/track/7ngZ2kMSW18SHZ7RG3QeOG',
-            description: 'Produced by RIQ'
-        },
-        {
-            id: '4',
-            title: 'mvp w/ j dean + sophia [OUT ON ALL PLATS]',
-            platform: 'soundcloud',
-            embedCode: `<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2065978932&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>`,
-            url: 'https://soundcloud.com/prodbyriq/mvp-w-j-dean-sophia?si=c61117b0c94148f4a442668189746841&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing',
-            description: 'Collaborative track featuring J Dean and Sophia'
-        }
-        // Add more tracks here as needed
-    ];
+  const [filter, setFilter] = useState<FilterValue>('all');
 
-    const filteredTracks = tracks.filter(track => {
-        if (filter === 'all') return true;
-        return track.platform === filter;
-    });
+  const filteredTracks = filter === 'all'
+    ? TRACKS
+    : TRACKS.filter(t => t.platform === filter);
 
-    const getFilterButtonClass = (buttonFilter: string) => {
-        return `filter-button ${filter === buttonFilter ? 'active' : ''}`;
-    };
+  const platformLabel = (p: Track['platform']) =>
+    p === 'spotify' ? 'Spotify' : 'SoundCloud';
 
-    return (
-        <div className="page-content">
-            <div className="featured-work-hero">
-                <h1>Featured Work</h1>
-                <p className="featured-work-subtitle">
-                    Explore my complete catalog of released music across all platforms
-                </p>
-                <p className="featured-work-description">
-                    From collaborative projects to solo productions, discover the full range of my musical work 
-                    available on Spotify, SoundCloud, and other streaming platforms.
-                </p>
-            </div>
+  return (
+    <div className="page-content fw-page">
 
-            <div className="filter-section">
-                <h2>Filter by Platform</h2>
-                <div className="filter-buttons">
-                    <button 
-                        className={getFilterButtonClass('all')}
-                        onClick={() => setFilter('all')}
-                    >
-                        All Platforms
-                    </button>
-                    <button 
-                        className={getFilterButtonClass('spotify')}
-                        onClick={() => setFilter('spotify')}
-                    >
-                        Spotify
-                    </button>
-                    <button 
-                        className={getFilterButtonClass('soundcloud')}
-                        onClick={() => setFilter('soundcloud')}
-                    >
-                        SoundCloud
-                    </button>
-                </div>
-            </div>
-
-            <div className="tracks-section">
-                <div className="tracks-count">
-                    <p>Showing {filteredTracks.length} track{filteredTracks.length !== 1 ? 's' : ''}</p>
-                </div>
-                
-                <div className="tracks-grid">
-                    {filteredTracks.length > 0 ? (
-                        filteredTracks.map((track) => (
-                            <div key={track.id} className="track-card">
-                                <div className="track-header">
-                                    <h3>{track.title}</h3>
-                                    <span className={`platform-badge ${track.platform}`}>
-                                        {track.platform === 'spotify' ? 'Spotify' : 'SoundCloud'}
-                                    </span>
-                                </div>
-                                
-                                {track.description && (
-                                    <p className="track-description">{track.description}</p>
-                                )}
-                                
-                                <div className="track-embed">
-                                    {track.platform === 'spotify' ? (
-                                        <div dangerouslySetInnerHTML={{ __html: track.embedCode }} />
-                                    ) : (
-                                        <div dangerouslySetInnerHTML={{ __html: track.embedCode }} />
-                                    )}
-                                </div>
-                                
-                                <div className="track-actions">
-                                    <a 
-                                        href={track.url} 
-                                        target="_blank" 
-                                        rel="noopener noreferrer"
-                                        className="track-link"
-                                    >
-                                        Listen on {track.platform === 'spotify' ? 'Spotify' : 'SoundCloud'}
-                                    </a>
-                                </div>
-                            </div>
-                        ))
-                    ) : (
-                        <div className="no-tracks">
-                            <p>No tracks found for the selected platform.</p>
-                        </div>
-                    )}
-                </div>
-            </div>
-
-            <div className="featured-work-cta">
-                <h2>Ready to Work Together?</h2>
-                <p>Let's create your next hit track</p>
-                <div className="cta-buttons">
-                    <Link to="/services" className="cta-button primary">Start a Project</Link>
-                    <Link to="/beats" className="cta-button secondary">Browse Beats</Link>
-                </div>
-            </div>
+      {/* ── Hero ─────────────────────────────────────────────── */}
+      <section className="fw-hero">
+        <div className="fw-container">
+          <p className="fw-eyebrow">Production · Mixing · Mastering</p>
+          <h1>Featured Work</h1>
+          <p className="fw-hero-sub">
+            Released music across Spotify, SoundCloud, and beyond — hip hop, drill, R&amp;B, and more.
+          </p>
         </div>
-    );
+      </section>
+
+      {/* ── Filter ───────────────────────────────────────────── */}
+      <section className="fw-filter-section">
+        <div className="fw-container">
+          <div className="fw-filter-bar" role="group" aria-label="Filter by platform">
+            {(['all', 'spotify', 'soundcloud'] as FilterValue[]).map(val => (
+              <button
+                key={val}
+                type="button"
+                className={`fw-filter-btn${filter === val ? ' fw-filter-btn--active' : ''}`}
+                onClick={() => setFilter(val)}
+                aria-pressed={filter === val}
+              >
+                {val === 'all' ? 'All Platforms' : val === 'spotify' ? 'Spotify' : 'SoundCloud'}
+              </button>
+            ))}
+          </div>
+          <p className="fw-track-count" aria-live="polite">
+            {filteredTracks.length} track{filteredTracks.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+      </section>
+
+      {/* ── Tracks Grid ──────────────────────────────────────── */}
+      <section className="fw-tracks-section" aria-labelledby="fw-tracks-heading">
+        <div className="fw-container">
+          <h2 id="fw-tracks-heading" className="fw-sr-only">Tracks</h2>
+          {filteredTracks.length > 0 ? (
+            <div className="fw-tracks-grid">
+              {filteredTracks.map(track => (
+                <article key={track.id} className="fw-track-card">
+                  <div className="fw-track-header">
+                    <h3 className="fw-track-title">{track.title}</h3>
+                    <span className={`fw-platform-badge fw-platform-badge--${track.platform}`}>
+                      {platformLabel(track.platform)}
+                    </span>
+                  </div>
+                  {track.description && (
+                    <p className="fw-track-desc">{track.description}</p>
+                  )}
+                  <div className="fw-track-embed">
+                    <div dangerouslySetInnerHTML={{ __html: track.embedCode }} />
+                  </div>
+                  <div className="fw-track-actions">
+                    <a
+                      href={track.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="fw-track-link"
+                    >
+                      Listen on {platformLabel(track.platform)}
+                    </a>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="fw-empty">No tracks found for the selected platform.</p>
+          )}
+        </div>
+      </section>
+
+      {/* ── CTA ──────────────────────────────────────────────── */}
+      <section className="fw-cta-section">
+        <div className="fw-container">
+          <div className="fw-cta-inner">
+            <h2>Ready to Work Together?</h2>
+            <p>Send your stems or browse beats — let&apos;s make something.</p>
+            <div className="fw-cta-buttons">
+              <Link to="/services" className="fw-cta-btn fw-cta-btn--primary">Start a Project</Link>
+              <Link to="/beats" className="fw-cta-btn fw-cta-btn--secondary">Browse Beats</Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  );
 };
 
 export default FeaturedWork;

--- a/src/pages/FeaturedWork.tsx
+++ b/src/pages/FeaturedWork.tsx
@@ -8,7 +8,9 @@ interface Track {
   id: string;
   title: string;
   platform: 'spotify' | 'soundcloud';
-  embedCode: string;
+  embedSrc: string;
+  embedHeight: number;
+  embedAllow?: string;
   url: string;
   description?: string;
 }
@@ -18,7 +20,9 @@ const TRACKS: Track[] = [
     id: '1',
     title: 'Track 1',
     platform: 'spotify',
-    embedCode: `<iframe src="https://open.spotify.com/embed/track/3rlbQrNDUyIpF5QPjpFCkV?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
+    embedSrc: 'https://open.spotify.com/embed/track/3rlbQrNDUyIpF5QPjpFCkV?utm_source=generator&theme=0',
+    embedHeight: 152,
+    embedAllow: 'autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture',
     url: 'https://open.spotify.com/track/3rlbQrNDUyIpF5QPjpFCkV',
     description: 'Mixed & Mastered by RIQ',
   },
@@ -26,7 +30,9 @@ const TRACKS: Track[] = [
     id: '2',
     title: 'Track 2',
     platform: 'spotify',
-    embedCode: `<iframe src="https://open.spotify.com/embed/track/2hNLyPN3fM0Ds7LASznUkX?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
+    embedSrc: 'https://open.spotify.com/embed/track/2hNLyPN3fM0Ds7LASznUkX?utm_source=generator&theme=0',
+    embedHeight: 152,
+    embedAllow: 'autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture',
     url: 'https://open.spotify.com/track/2hNLyPN3fM0Ds7LASznUkX',
     description: 'Mixed & Mastered by RIQ',
   },
@@ -34,7 +40,9 @@ const TRACKS: Track[] = [
     id: '3',
     title: 'Track 3',
     platform: 'spotify',
-    embedCode: `<iframe src="https://open.spotify.com/embed/track/7ngZ2kMSW18SHZ7RG3QeOG?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>`,
+    embedSrc: 'https://open.spotify.com/embed/track/7ngZ2kMSW18SHZ7RG3QeOG?utm_source=generator&theme=0',
+    embedHeight: 152,
+    embedAllow: 'autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture',
     url: 'https://open.spotify.com/track/7ngZ2kMSW18SHZ7RG3QeOG',
     description: 'Produced by RIQ',
   },
@@ -42,7 +50,9 @@ const TRACKS: Track[] = [
     id: '4',
     title: 'mvp w/ j dean + sophia [OUT ON ALL PLATS]',
     platform: 'soundcloud',
-    embedCode: `<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2065978932&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>`,
+    embedSrc: 'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2065978932&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true',
+    embedHeight: 166,
+    embedAllow: 'autoplay',
     url: 'https://soundcloud.com/prodbyriq/mvp-w-j-dean-sophia?si=c61117b0c94148f4a442668189746841&utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing',
     description: 'Collaborative track featuring J Dean and Sophia',
   },
@@ -120,7 +130,15 @@ const FeaturedWork = () => {
                     <p className="fw-track-desc">{track.description}</p>
                   )}
                   <div className="fw-track-embed">
-                    <div dangerouslySetInnerHTML={{ __html: track.embedCode.replace('<iframe', `<iframe title="${track.title} on ${platformLabel(track.platform)}"`) }} />
+                    <iframe
+                      src={track.embedSrc}
+                      width="100%"
+                      height={track.embedHeight}
+                      title={`${track.title} on ${platformLabel(track.platform)}`}
+                      allow={track.embedAllow}
+                      loading="lazy"
+                      frameBorder="0"
+                    />
                   </div>
                   <div className="fw-track-actions">
                     <a

--- a/src/pages/FeaturedWork.tsx
+++ b/src/pages/FeaturedWork.tsx
@@ -120,7 +120,7 @@ const FeaturedWork = () => {
                     <p className="fw-track-desc">{track.description}</p>
                   )}
                   <div className="fw-track-embed">
-                    <div dangerouslySetInnerHTML={{ __html: track.embedCode }} />
+                    <div dangerouslySetInnerHTML={{ __html: track.embedCode.replace('<iframe', `<iframe title="${track.title} on ${platformLabel(track.platform)}"`) }} />
                   </div>
                   <div className="fw-track-actions">
                     <a

--- a/src/pages/FeaturedWork.tsx
+++ b/src/pages/FeaturedWork.tsx
@@ -136,6 +136,7 @@ const FeaturedWork = () => {
                       height={track.embedHeight}
                       title={`${track.title} on ${platformLabel(track.platform)}`}
                       allow={track.embedAllow}
+                      allowFullScreen
                       loading="lazy"
                       frameBorder="0"
                     />

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -5,106 +5,106 @@ import '../styles/PageContent.css';
 import '../styles/Success.css';
 
 const Success = () => {
-    const [sessionId, setSessionId] = useState<string | null>(null);
-    const [hasConsultation, setHasConsultation] = useState(false);
-    const [loading, setLoading] = useState(true);
-    const location = useLocation();
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [hasConsultation, setHasConsultation] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const location = useLocation();
 
-    usePageMeta({
-        title: 'Order Confirmed | PRODBYRIQ',
-        description: 'Your order has been confirmed. Thank you for your purchase.',
-        canonicalPath: '/success',
-        noIndex: true,
-    });
+  usePageMeta({
+    title: 'Order Confirmed | PRODBYRIQ',
+    description: 'Your order has been confirmed. Thank you for your purchase.',
+    canonicalPath: '/success',
+    noIndex: true,
+  });
 
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const stripeSessionId = params.get('session_id');
-        const consultationFlag = params.get('has_consultation');
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const stripeSessionId = params.get('session_id');
+    const consultationFlag = params.get('has_consultation');
+    // Reset all state so navigating to a different /success URL never shows stale data
+    setSessionId(stripeSessionId);
+    setHasConsultation(consultationFlag === '1');
+    setLoading(false);
+  }, [location.search]);
 
-        // Reset all state so navigating to a different /success URL never shows stale data
-        setSessionId(stripeSessionId);
-        setHasConsultation(consultationFlag === '1');
-        setLoading(false);
-    }, [location.search]);
-
-    if (loading) {
-        return (
-            <div className="page-content">
-                <div className="success-container">
-                    <div className="loading-message">
-                        <h3>Processing your order…</h3>
-                        <p>Please wait while we confirm your payment.</p>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-
-    if (!sessionId) {
-        return (
-            <div className="page-content">
-                <div className="success-container">
-                    <div className="error-message">
-                        <h3>No order found</h3>
-                        <p>This page can only be accessed after a completed checkout.</p>
-                        <Link to="/" className="home-button">Return to Home</Link>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-
+  if (loading) {
     return (
-        <div className="page-content">
-            <h2>Payment Successful!</h2>
-
-            <div className="success-container">
-                <div className="success-icon">✓</div>
-
-                <div className="success-message">
-                    <h3>Thank you for your purchase</h3>
-                    <p>Your order has been confirmed. You'll receive a confirmation email shortly.</p>
-
-                    {sessionId && (
-                        <p className="booking-reference">
-                            Order Reference: <span>{sessionId}</span>
-                        </p>
-                    )}
-
-                    {hasConsultation ? (
-                        <div className="consultation-booking">
-                            <h4>Book Your Consultation Session</h4>
-                            <p>Select a time slot for your artist consultation:</p>
-                            <div className="calendar-container">
-                                <iframe
-                                    src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ2hV23dUVFD8uG_Z_K-1SkgVvAjw7yYxG9PzkSZ9kjWiC3l53mS8iFK5lfAMfiiVuJn5A-NR58r?gv=true"
-                                    style={{ border: 0 }}
-                                    width="100%"
-                                    height="600"
-                                    frameBorder="0"
-                                    title="Book Consultation Session"
-                                />
-                            </div>
-                        </div>
-                    ) : (
-                        <div className="next-steps">
-                            <h4>Next Steps</h4>
-                            <ol>
-                                <li>You'll receive an email confirmation with order details</li>
-                                <li>For mixing / mastering services, RIQ will reach out with stem upload instructions</li>
-                                <li>For beat leases, download links will be provided via email</li>
-                            </ol>
-                        </div>
-                    )}
-
-                    <div className="action-buttons">
-                        <Link to="/" className="home-button">Return to Home</Link>
-                    </div>
-                </div>
-            </div>
+      <div className="page-content">
+        <div className="succ-center">
+          <p className="succ-loading">Confirming your order…</p>
         </div>
+      </div>
     );
+  }
+
+  if (!sessionId) {
+    return (
+      <div className="page-content">
+        <div className="succ-center">
+          <div className="succ-error">
+            <h2>No order found</h2>
+            <p>This page can only be accessed after a completed checkout.</p>
+            <Link to="/" className="succ-home-btn">Return to Home</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-content succ-page">
+      <div className="succ-container">
+
+        {/* ── Icon ─────────────────────────────────────────── */}
+        <div className="succ-icon-wrap" aria-hidden="true">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+
+        {/* ── Heading ──────────────────────────────────────── */}
+        <h1 className="succ-heading">Order Confirmed</h1>
+        <p className="succ-subheading">
+          Thank you for your purchase. You&apos;ll receive a Stripe receipt via email shortly.
+        </p>
+
+        {/* ── Reference ────────────────────────────────────── */}
+        <div className="succ-reference">
+          <span className="succ-reference-label">Order reference</span>
+          <code className="succ-reference-value">{sessionId}</code>
+        </div>
+
+        {/* ── Next Steps ───────────────────────────────────── */}
+        {hasConsultation ? (
+          <div className="succ-block">
+            <h2>Book Your Consultation</h2>
+            <p>Select a time slot for your artist consultation session:</p>
+            <div className="succ-calendar">
+              <iframe
+                src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ2hV23dUVFD8uG_Z_K-1SkgVvAjw7yYxG9PzkSZ9kjWiC3l53mS8iFK5lfAMfiiVuJn5A-NR58r?gv=true"
+                style={{ border: 0 }}
+                width="100%"
+                height="600"
+                frameBorder="0"
+                title="Book Consultation Session"
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="succ-block">
+            <h2>What Happens Next</h2>
+            <ol className="succ-steps">
+              <li>RIQ will reach out with stem upload instructions for mixing / mastering orders</li>
+              <li>Beat lease download links will be sent to your email</li>
+              <li>Turnaround begins once your files are received</li>
+            </ol>
+          </div>
+        )}
+
+        <Link to="/" className="succ-home-btn">Return to Home</Link>
+      </div>
+    </div>
+  );
 };
 
 export default Success;

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -4,6 +4,9 @@ import { useLocation, Link } from 'react-router-dom';
 import '../styles/PageContent.css';
 import '../styles/Success.css';
 
+const CONSULTATION_CALENDAR_URL =
+  'https://calendar.google.com/calendar/appointments/schedules/AcZssZ2hV23dUVFD8uG_Z_K-1SkgVvAjw7yYxG9PzkSZ9kjWiC3l53mS8iFK5lfAMfiiVuJn5A-NR58r?gv=true';
+
 const Success = () => {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [hasConsultation, setHasConsultation] = useState(false);
@@ -81,7 +84,7 @@ const Success = () => {
             <p>Select a time slot for your artist consultation session:</p>
             <div className="succ-calendar">
               <iframe
-                src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ2hV23dUVFD8uG_Z_K-1SkgVvAjw7yYxG9PzkSZ9kjWiC3l53mS8iFK5lfAMfiiVuJn5A-NR58r?gv=true"
+                src={CONSULTATION_CALENDAR_URL}
                 style={{ border: 0 }}
                 width="100%"
                 height="600"

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -90,6 +90,7 @@ const Success = () => {
                 height="600"
                 frameBorder="0"
                 title="Book Consultation Session"
+                loading="lazy"
               />
             </div>
           </div>

--- a/src/styles/About.css
+++ b/src/styles/About.css
@@ -1,316 +1,216 @@
-.about-hero {
+/* ── Layout ────────────────────────────────────────────────── */
+.ab-page {
+  padding-bottom: 5rem;
+}
+
+.ab-container {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* ── Hero ──────────────────────────────────────────────────── */
+.ab-hero {
   text-align: center;
-  padding: 3rem 0;
-  background: linear-gradient(135deg, var(--color-accent-3) 0%, var(--color-lightest) 100%);
-  color: var(--text-dark);
-  border-radius: 12px;
-  margin-bottom: 3rem;
-  border: 2px solid var(--color-neutral-3);
-  box-shadow: 0 4px 16px rgba(45, 45, 45, 0.1);
+  padding: 4rem 1.5rem 3rem;
+  border-bottom: 1px solid var(--border-default);
+  margin-bottom: 4rem;
 }
 
-.about-content h1 {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-  font-weight: 700;
-  color: var(--text-dark);
-}
-
-.about-subtitle {
-  font-size: 1.2rem;
-  color: var(--text-medium);
+.ab-eyebrow {
+  font-size: 0.8rem;
   font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
 }
 
-.about-sections {
+.ab-hero h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 1rem;
+  line-height: 1.15;
+}
+
+.ab-hero-sub {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  max-width: 520px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* ── Bio ───────────────────────────────────────────────────── */
+.ab-bio-section {
+  margin-bottom: 4rem;
+}
+
+.ab-bio-grid {
   display: flex;
-  flex-direction: column;
   gap: 3rem;
+  align-items: flex-start;
 }
 
-.about-section {
-  background: var(--color-neutral-1);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 12px;
-  padding: 2rem;
-  box-shadow: 0 4px 12px rgba(45, 45, 45, 0.1);
-  transition: all 0.3s ease;
-}
-
-.about-section:hover {
-  transform: translateY(-2px);
-  border-color: var(--color-accent-3);
-  box-shadow: 0 8px 24px rgba(45, 45, 45, 0.15);
-}
-
-.about-section h2 {
-  font-size: 2rem;
-  margin-bottom: 1.5rem;
-  color: var(--text-dark);
-  font-weight: 700;
-}
-
-.about-section p {
-  font-size: 1.1rem;
-  line-height: 1.7;
-  color: var(--text-medium);
-  margin-bottom: 1.5rem;
-}
-
-.services-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.service-item {
-  background: var(--color-light);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 8px;
-  padding: 1.5rem;
-  border-left: 4px solid var(--color-accent-3);
-  transition: all 0.3s ease;
-}
-
-.service-item:hover {
-  background: var(--color-light-2);
-  border-color: var(--color-accent-3);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(45, 45, 45, 0.1);
-}
-
-.service-item h3 {
-  font-size: 1.3rem;
-  margin-bottom: 0.5rem;
-  color: var(--text-dark);
-  font-weight: 700;
-}
-
-.service-item p {
-  font-size: 1rem;
-  color: var(--text-medium);
-  margin: 0;
-}
-
-.contact-info {
-  background: var(--color-accent-3);
-  border: 2px solid var(--color-accent-3);
-  border-radius: 8px;
-  padding: 1.5rem;
-  margin-top: 1rem;
-  text-align: center;
-  transition: all 0.3s ease;
-}
-
-.contact-info:hover {
-  background: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(45, 45, 45, 0.15);
-}
-
-.contact-info p {
-  margin: 0;
-  font-weight: 700;
-  color: var(--text-dark);
-  font-size: 1.1rem;
-}
-
-@media (max-width: 768px) {
-  .about-content h1 {
-    font-size: 2rem;
-  }
-  
-  .about-section {
-    padding: 1.5rem;
-  }
-  
-  .services-list {
-    grid-template-columns: 1fr;
-  }
-  
-  .about-hero {
-    padding: 2rem 0;
-  }
-  
-  .about-section h2 {
-    font-size: 1.5rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .about-content h1 {
-    font-size: 1.8rem;
-  }
-  
-  .about-subtitle {
-    font-size: 1rem;
-  }
-  
-  .about-section {
-    padding: 1rem;
-  }
-  
-  .service-item {
-    padding: 1rem;
-  }
-}
-
-/* High contrast mode support */
-@media (prefers-contrast: high) {
-  .about-hero,
-  .about-section,
-  .service-item,
-  .contact-info {
-    border-width: 3px;
-  }
-}
-
-/* Focus styles for accessibility */
-.service-item:focus,
-.contact-info:focus {
-  outline: 3px solid var(--color-accent-3);
-  outline-offset: 2px;
-}
-
-/* Producer Photo Section */
-.about-photo-section {
-  display: flex;
-  gap: 2.5rem;
-  align-items: center;
-  background: var(--color-neutral-1);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 12px;
-  padding: 2rem;
-  margin-bottom: 3rem;
-  box-shadow: 0 4px 12px rgba(45, 45, 45, 0.1);
-}
-
-.about-photo-wrapper {
+.ab-photo-wrap {
   flex-shrink: 0;
 }
 
-.about-photo-placeholder {
+.ab-photo-placeholder {
   width: 160px;
   height: 160px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-accent-3) 0%, var(--color-neutral-3) 100%);
+  border-radius: var(--radius-full);
+  background: linear-gradient(135deg, var(--tan) 0%, var(--pale-oak) 100%);
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 3px solid var(--color-accent-3);
+  border: 3px solid var(--border-strong);
 }
 
-.about-photo-initials {
-  font-size: 2.5rem;
+.ab-photo-initials {
+  font-family: var(--font-display);
+  font-size: 2.25rem;
   font-weight: 700;
-  color: var(--text-dark);
-  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
 }
 
-.about-photo-bio h2 {
-  font-size: 1.8rem;
+.ab-bio-body h2 {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
   font-weight: 700;
-  color: var(--text-dark);
+  color: var(--text-heading);
   margin-bottom: 0.25rem;
 }
 
-.about-photo-role {
-  font-size: 1rem;
+.ab-bio-role {
+  font-size: 0.85rem;
   font-weight: 600;
-  color: var(--text-medium);
-  margin-bottom: 1rem;
-  letter-spacing: 0.03em;
-}
-
-.about-photo-bio p:not(.about-photo-role) {
-  font-size: 1.05rem;
-  line-height: 1.7;
-  color: var(--text-medium);
-  margin: 0;
-}
-
-/* Credits Section */
-.about-credits-intro {
-  font-size: 1rem;
-  color: var(--text-medium);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
   margin-bottom: 1.25rem;
 }
 
-.about-credits-list {
+.ab-bio-body p:not(.ab-bio-role) {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--text-secondary);
+  margin-bottom: 0.875rem;
+}
+
+/* ── Credits ───────────────────────────────────────────────── */
+.ab-credits-section {
+  margin-bottom: 4rem;
+  padding-top: 3rem;
+  border-top: 1px solid var(--border-default);
+}
+
+.ab-credits-section h2,
+.ab-testimonials-section h2 {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 0.5rem;
+}
+
+.ab-section-sub {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin-bottom: 1.75rem;
+}
+
+.ab-credits-list {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.625rem;
 }
 
-.about-credit-item {
+.ab-credit-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1rem;
-  background: var(--color-light);
-  border: 1px solid var(--color-neutral-3);
-  border-left: 4px solid var(--color-accent-3);
-  border-radius: 6px;
+  padding: 0.875rem 1.125rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--accent-primary);
+  border-radius: var(--radius-sm);
 }
 
-.about-credit-title {
-  font-size: 1rem;
+.ab-credit-title {
+  font-size: 0.95rem;
   font-weight: 600;
-  color: var(--text-dark);
+  color: var(--text-primary);
 }
 
-.about-credit-role {
-  font-size: 0.9rem;
-  color: var(--text-medium);
+.ab-credit-role {
+  font-size: 0.875rem;
+  color: var(--text-muted);
   font-style: italic;
 }
 
-/* Testimonials */
-.about-testimonials {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+/* ── Testimonials ──────────────────────────────────────────── */
+.ab-testimonials-section {
+  padding-top: 3rem;
+  border-top: 1px solid var(--border-default);
 }
 
-.about-testimonial {
-  background: var(--color-light);
-  border: 1px solid var(--color-neutral-3);
-  border-left: 4px solid var(--color-accent-3);
-  border-radius: 6px;
-  padding: 1.25rem 1.5rem;
+.ab-testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.75rem;
+}
+
+.ab-testimonial {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--accent-primary);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
   margin: 0;
 }
 
-.about-testimonial p {
-  font-size: 1.05rem;
+.ab-testimonial p {
+  font-size: 1rem;
   font-style: italic;
-  color: var(--text-dark);
-  margin-bottom: 0.75rem;
-  line-height: 1.6;
+  color: var(--text-primary);
+  line-height: 1.65;
+  margin-bottom: 0.875rem;
 }
 
-.about-testimonial cite {
-  font-size: 0.9rem;
+.ab-testimonial cite {
+  font-size: 0.875rem;
   font-weight: 600;
-  color: var(--text-medium);
+  color: var(--text-muted);
   font-style: normal;
 }
 
+/* ── Responsive ────────────────────────────────────────────── */
 @media (max-width: 640px) {
-  .about-photo-section {
+  .ab-bio-grid {
     flex-direction: column;
-    text-align: center;
     align-items: center;
+    text-align: center;
   }
 
-  .about-credit-item {
+  .ab-credit-item {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.25rem;
   }
+
+  .ab-testimonials-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
 }

--- a/src/styles/About.css
+++ b/src/styles/About.css
@@ -212,5 +212,5 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * { transition: none !important; }
+  .ab-page * { transition: none !important; }
 }

--- a/src/styles/FeaturedWork.css
+++ b/src/styles/FeaturedWork.css
@@ -277,6 +277,7 @@
 .fw-cta-btn--secondary:hover {
   background: var(--almond);
   border-color: var(--tan);
+  color: var(--text-primary);
 }
 
 /* ── Responsive ────────────────────────────────────────────── */

--- a/src/styles/FeaturedWork.css
+++ b/src/styles/FeaturedWork.css
@@ -265,9 +265,12 @@
   border: 1px solid var(--accent-primary);
 }
 
-.fw-cta-btn--primary:hover {
+.fw-cta-btn--primary:hover,
+.fw-cta-btn--primary:focus,
+.fw-cta-btn--primary:visited {
   background: var(--accent-hover);
   border-color: var(--accent-hover);
+  color: #fff;
 }
 
 .fw-cta-btn--secondary {

--- a/src/styles/FeaturedWork.css
+++ b/src/styles/FeaturedWork.css
@@ -84,6 +84,7 @@
   border-color: var(--accent-primary);
   color: var(--text-primary);
   background: var(--bg-elevated);
+  transform: none;
 }
 
 .fw-filter-btn--active {
@@ -97,6 +98,7 @@
   background: var(--accent-hover);
   border-color: var(--accent-hover);
   color: #fff;
+  transform: none;
 }
 
 .fw-track-count {

--- a/src/styles/FeaturedWork.css
+++ b/src/styles/FeaturedWork.css
@@ -1,273 +1,305 @@
-.featured-work-hero {
+/* ── Layout ────────────────────────────────────────────────── */
+.fw-page {
+  padding-bottom: 5rem;
+}
+
+.fw-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.fw-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Hero ──────────────────────────────────────────────────── */
+.fw-hero {
   text-align: center;
-  padding: 3rem 0;
-  background: linear-gradient(135deg, var(--color-accent-3) 0%, var(--color-lightest) 100%);
-  color: var(--text-dark);
-  border-radius: 12px;
-  margin-bottom: 3rem;
-  border: 2px solid var(--color-neutral-3);
-  box-shadow: 0 4px 16px rgba(45, 45, 45, 0.1);
+  padding: 4rem 1.5rem 3rem;
+  border-bottom: 1px solid var(--border-default);
+  margin-bottom: 2.5rem;
 }
 
-.featured-work-hero h1 {
-  font-size: 2.5rem;
+.fw-eyebrow {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
   margin-bottom: 1rem;
-  font-weight: 700;
-  color: var(--text-dark);
 }
 
-.featured-work-subtitle {
-  font-size: 1.2rem;
-  margin-bottom: 1.5rem;
-  color: var(--text-dark);
+.fw-hero h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 1rem;
+  line-height: 1.15;
+}
+
+.fw-hero-sub {
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  max-width: 520px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* ── Filter Bar ────────────────────────────────────────────── */
+.fw-filter-section {
+  margin-bottom: 2.5rem;
+}
+
+.fw-filter-bar {
+  display: flex;
+  gap: 0.625rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.fw-filter-btn {
+  padding: 0.5rem 1.25rem;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border-radius: var(--radius-full);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.fw-filter-btn:hover {
+  border-color: var(--accent-primary);
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.fw-filter-btn--active {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: #fff;
   font-weight: 600;
 }
 
-.featured-work-description {
-  font-size: 1.1rem;
-  max-width: 600px;
-  margin: 0 auto;
-  line-height: 1.6;
-  color: var(--text-medium);
+.fw-filter-btn--active:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
 }
 
-.filter-section {
-  margin: 3rem 0;
+.fw-track-count {
   text-align: center;
+  font-size: 0.875rem;
+  color: var(--text-muted);
 }
 
-.filter-section h2 {
-  font-size: 2rem;
-  margin-bottom: 2rem;
-  color: var(--text-dark);
+/* ── Tracks Grid ───────────────────────────────────────────── */
+.fw-tracks-section {
+  margin-bottom: 4rem;
+}
+
+.fw-tracks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 1.75rem;
+}
+
+.fw-track-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-default), border-color var(--transition-default);
+}
+
+.fw-track-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--border-strong);
+}
+
+.fw-track-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0.625rem;
+}
+
+.fw-track-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  flex: 1;
+  line-height: 1.4;
+}
+
+.fw-platform-badge {
+  padding: 0.2rem 0.625rem;
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.fw-platform-badge--spotify {
+  background: #1db954;
+  color: #fff;
+}
+
+.fw-platform-badge--soundcloud {
+  background: #ff5500;
+  color: #fff;
+}
+
+.fw-track-desc {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+.fw-track-embed {
+  margin: 1rem 0;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.fw-track-actions {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.fw-track-link {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.fw-track-link:hover {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: #fff;
+}
+
+.fw-empty {
+  text-align: center;
+  padding: 3rem;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+/* ── CTA ───────────────────────────────────────────────────── */
+.fw-cta-section {
+  border-top: 1px solid var(--border-default);
+  padding-top: 4rem;
+}
+
+.fw-cta-inner {
+  text-align: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 3rem 2rem;
+}
+
+.fw-cta-inner h2 {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
   font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 0.625rem;
 }
 
-.filter-buttons {
+.fw-cta-inner p {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+}
+
+.fw-cta-buttons {
   display: flex;
   gap: 1rem;
   justify-content: center;
   flex-wrap: wrap;
 }
 
-.filter-button {
-  padding: 10px 20px;
-  border: 2px solid var(--color-neutral-3);
-  background-color: var(--color-neutral-1);
-  color: var(--text-medium);
-  border-radius: 6px;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: 0 2px 4px rgba(45, 45, 45, 0.1);
-}
-
-.filter-button:hover {
-  border-color: var(--color-accent-3);
-  color: var(--text-dark);
-  background-color: var(--color-light);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(45, 45, 45, 0.15);
-}
-
-.filter-button.active {
-  background-color: var(--color-accent-3);
-  border-color: var(--color-accent-3);
-  color: var(--text-dark);
-  font-weight: 700;
-}
-
-.tracks-section {
-  margin: 3rem 0;
-}
-
-.tracks-count {
-  text-align: center;
-  margin-bottom: 2rem;
-  color: var(--text-medium);
-  font-size: 1.1rem;
-  font-weight: 500;
-}
-
-.tracks-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 2rem;
-}
-
-.track-card {
-  background: var(--color-neutral-1);
-  border: 2px solid var(--color-neutral-3);
-  border-radius: 12px;
-  padding: 2rem;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 12px rgba(45, 45, 45, 0.1);
-}
-
-.track-card:hover {
-  transform: translateY(-5px);
-  border-color: var(--color-accent-3);
-  box-shadow: 0 8px 24px rgba(45, 45, 45, 0.15);
-}
-
-.track-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 1rem;
-  gap: 1rem;
-}
-
-.track-header h3 {
-  font-size: 1.3rem;
-  color: var(--text-dark);
-  margin: 0;
-  flex: 1;
-  font-weight: 700;
-}
-
-.platform-badge {
-  padding: 4px 12px;
-  border-radius: 20px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  white-space: nowrap;
-  border: 2px solid;
-}
-
-.platform-badge.spotify {
-  background-color: #1db954;
-  color: white;
-  border-color: #1db954;
-}
-
-.platform-badge.soundcloud {
-  background-color: #ff5500;
-  color: white;
-  border-color: #ff5500;
-}
-
-.track-description {
-  color: var(--text-medium);
-  margin-bottom: 1.5rem;
-  line-height: 1.6;
-}
-
-.track-embed {
-  margin: 1.5rem 0;
-  border-radius: 8px;
-  overflow: hidden;
-}
-
-.track-embed iframe {
-  border-radius: 8px;
-}
-
-.track-actions {
-  margin-top: 1.5rem;
-  text-align: center;
-}
-
-.track-link {
+.fw-cta-btn {
   display: inline-block;
-  padding: 10px 20px;
-  background-color: var(--color-accent-3);
-  color: var(--text-dark);
-  border: 2px solid var(--color-accent-3);
-  border-radius: 6px;
-  text-decoration: none;
+  padding: 0.75rem 1.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
   font-weight: 600;
-  transition: all 0.3s ease;
+  text-decoration: none;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
 }
 
-.track-link:hover {
-  background-color: var(--color-lightest);
-  border-color: var(--color-lightest);
-  transform: translateY(-1px);
+.fw-cta-btn--primary {
+  background: var(--accent-primary);
+  color: #fff;
+  border: 1px solid var(--accent-primary);
 }
 
-.no-tracks {
-  text-align: center;
-  padding: 3rem;
-  color: var(--text-medium);
-  font-size: 1.1rem;
+.fw-cta-btn--primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
-.featured-work-cta {
-  text-align: center;
-  padding: 3rem;
-  background: linear-gradient(135deg, var(--color-accent-3) 0%, var(--color-lightest) 100%);
-  color: var(--text-dark);
-  border-radius: 12px;
-  margin: 4rem 0;
-  border: 2px solid var(--color-neutral-3);
-  box-shadow: 0 4px 16px rgba(45, 45, 45, 0.1);
+.fw-cta-btn--secondary {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border: 1px solid var(--border-strong);
 }
 
-.featured-work-cta h2 {
-  font-size: 2rem;
-  margin-bottom: 1rem;
-  color: var(--text-dark);
-  font-weight: 700;
+.fw-cta-btn--secondary:hover {
+  background: var(--almond);
+  border-color: var(--tan);
 }
 
-.featured-work-cta p {
-  font-size: 1.1rem;
-  margin-bottom: 2rem;
-  color: var(--text-medium);
-}
-
-@media (max-width: 768px) {
-  .featured-work-hero h1 {
-    font-size: 2rem;
-  }
-  
-  .filter-buttons {
-    flex-direction: column;
-    align-items: center;
-  }
-  
-  .filter-button {
-    width: 200px;
-  }
-  
-  .tracks-grid {
+/* ── Responsive ────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .fw-tracks-grid {
     grid-template-columns: 1fr;
   }
-  
-  .track-header {
+
+  .fw-track-header {
     flex-direction: column;
     align-items: flex-start;
   }
-  
-  .cta-buttons {
+
+  .fw-cta-buttons {
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
+  }
+
+  .fw-cta-btn {
+    text-align: center;
   }
 }
 
-/* High contrast mode support */
-@media (prefers-contrast: high) {
-  .featured-work-hero,
-  .featured-work-cta {
-    border-width: 3px;
-  }
-  
-  .track-card {
-    border-width: 3px;
-  }
-  
-  .filter-button,
-  .track-link {
-    border-width: 3px;
-  }
-}
-
-/* Focus styles for accessibility */
-.filter-button:focus,
-.track-link:focus {
-  outline: 3px solid var(--color-accent-3);
-  outline-offset: 2px;
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
 }

--- a/src/styles/FeaturedWork.css
+++ b/src/styles/FeaturedWork.css
@@ -301,5 +301,5 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * { transition: none !important; }
+  .fw-page * { transition: none !important; }
 }

--- a/src/styles/Success.css
+++ b/src/styles/Success.css
@@ -189,5 +189,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * { transition: none !important; }
+  .succ-page *,
+  .succ-center * { transition: none !important; }
 }

--- a/src/styles/Success.css
+++ b/src/styles/Success.css
@@ -1,228 +1,193 @@
-.success-container {
-  max-width: 600px;
-  margin: 0 auto;
-  text-align: center;
-  background: #161b22;
-  border: 1px solid #30363d;
-  border-radius: 12px;
-  padding: 3rem;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+/* ── Layout ────────────────────────────────────────────────── */
+.succ-page {
+  display: flex;
+  justify-content: center;
+  padding: 4rem 1.5rem;
 }
 
-.success-icon {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  background-color: #238636;
-  color: white;
+.succ-container {
+  width: 100%;
+  max-width: 580px;
+  text-align: center;
+}
+
+.succ-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 40vh;
+  padding: 2rem;
+}
+
+/* ── Loading / Error ───────────────────────────────────────── */
+.succ-loading {
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.succ-error {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem 2rem;
+  text-align: center;
+}
+
+.succ-error h2 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--error);
+  margin-bottom: 0.625rem;
+}
+
+.succ-error p {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+/* ── Success Icon ──────────────────────────────────────────── */
+.succ-icon-wrap {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-full);
+  background: var(--success);
+  color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2.5rem;
-  font-weight: bold;
-  margin: 0 auto 2rem;
-  animation: successPulse 2s ease-in-out infinite;
+  margin: 0 auto 1.75rem;
 }
 
-@keyframes successPulse {
-  0% {
-    transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(35, 134, 54, 0.7);
-  }
-  70% {
-    transform: scale(1.05);
-    box-shadow: 0 0 0 10px rgba(35, 134, 54, 0);
-  }
-  100% {
-    transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(35, 134, 54, 0);
-  }
+/* ── Heading ───────────────────────────────────────────────── */
+.succ-heading {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 0.625rem;
 }
 
-.success-message h3 {
-  font-size: 2rem;
-  margin-bottom: 1rem;
-  color: #e1e5e9;
-}
-
-.success-message > p {
-  font-size: 1.1rem;
-  color: #8b949e;
+.succ-subheading {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
   margin-bottom: 2rem;
-  line-height: 1.6;
 }
 
-.booking-reference {
-  background: #0d1117;
-  border: 1px solid #30363d;
-  border-radius: 8px;
-  padding: 1rem;
-  margin: 1.5rem 0;
-  border-left: 4px solid #238636;
-}
-
-.booking-reference span {
-  font-weight: bold;
-  color: #238636;
-  font-family: monospace;
-  font-size: 1.1rem;
-}
-
-.next-steps {
+/* ── Reference ─────────────────────────────────────────────── */
+.succ-reference {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.375rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--accent-primary);
+  border-radius: var(--radius-sm);
+  padding: 1rem 1.25rem;
+  margin-bottom: 2rem;
   text-align: left;
-  background: #0d1117;
-  border: 1px solid #30363d;
-  border-radius: 8px;
-  padding: 2rem;
-  margin: 2rem 0;
 }
 
-.next-steps h4 {
-  font-size: 1.3rem;
-  margin-bottom: 1rem;
-  color: #e1e5e9;
-  text-align: center;
-}
-
-.next-steps ol {
-  padding-left: 1.5rem;
-  margin: 0;
-}
-
-.next-steps li {
-  margin-bottom: 0.8rem;
-  color: #8b949e;
-  line-height: 1.6;
-}
-
-.action-buttons {
-  margin-top: 2rem;
-}
-
-.home-button {
-  display: inline-block;
-  padding: 12px 24px;
-  background-color: #238636;
-  color: white;
-  text-decoration: none;
-  border-radius: 6px;
+.succ-reference-label {
+  font-size: 0.75rem;
   font-weight: 600;
-  transition: all 0.3s ease;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
-.home-button:hover {
-  background-color: #2ea043;
-  transform: translateY(-2px);
+.succ-reference-value {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  word-break: break-all;
 }
 
-/* Consultation Booking Styles */
-.consultation-booking {
-  margin: 2rem 0;
-  padding: 2rem;
-  background: #0d1117;
-  border: 1px solid #30363d;
-  border-radius: 8px;
-  border-left: 4px solid #238636;
+/* ── Content Block ─────────────────────────────────────────── */
+.succ-block {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  text-align: left;
+  margin-bottom: 2rem;
 }
 
-.consultation-booking h4 {
-  margin: 0 0 1rem 0;
-  color: #e1e5e9;
-  font-size: 1.3rem;
-  text-align: center;
+.succ-block h2 {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-heading);
+  margin-bottom: 0.625rem;
 }
 
-.consultation-booking p {
-  margin: 0 0 1.5rem 0;
-  color: #8b949e;
+.succ-block p {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.25rem;
   line-height: 1.6;
-  text-align: center;
 }
 
-.calendar-container {
-  border-radius: 8px;
+.succ-steps {
+  padding-left: 1.25rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.succ-steps li {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ── Calendar ──────────────────────────────────────────────── */
+.succ-calendar {
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  border: 1px solid #30363d;
+  border: 1px solid var(--border-default);
+  margin-top: 1rem;
 }
 
-.calendar-container iframe {
+.succ-calendar iframe {
   display: block;
   width: 100%;
   min-height: 600px;
-  background: white;
+  background: #fff;
 }
 
-/* Loading and Error States */
-.loading-message,
-.error-message {
-  text-align: center;
-  padding: 2rem;
+/* ── Home Button ───────────────────────────────────────────── */
+.succ-home-btn {
+  display: inline-block;
+  padding: 0.75rem 2rem;
+  background: var(--accent-primary);
+  color: #fff;
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
-.loading-message h3,
-.error-message h3 {
-  margin: 0 0 1rem 0;
-  color: #e1e5e9;
+.succ-home-btn:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
-.loading-message p,
-.error-message p {
-  margin: 0 0 1.5rem 0;
-  color: #8b949e;
-}
-
-.error-message {
-  /* background-color: #2d1b1b; */
-  border: 1px solid #5a2d2d;
-  border-radius: 8px;
-}
-
-.error-message h3 {
-  color: #f85149;
-}
-
-@media (max-width: 768px) {
-  .success-container {
-    padding: 2rem;
-    margin: 1rem;
-  }
-  
-  .success-icon {
-    width: 60px;
-    height: 60px;
-    font-size: 2rem;
-  }
-  
-  .success-message h3 {
-    font-size: 1.5rem;
-  }
-  
-  .next-steps {
-    padding: 1.5rem;
-  }
-  
-  .consultation-booking {
-    margin: 1.5rem 0;
-    padding: 1.5rem;
-  }
-  
-  .calendar-container iframe {
-    min-height: 500px;
-  }
-}
-
+/* ── Responsive ────────────────────────────────────────────── */
 @media (max-width: 480px) {
-  .consultation-booking {
-    margin: 1rem 0;
-    padding: 1rem;
+  .succ-container {
+    padding: 0;
   }
-  
-  .consultation-booking h4 {
-    font-size: 1.1rem;
+
+  .succ-calendar iframe {
+    min-height: 480px;
   }
-  
-  .calendar-container iframe {
-    min-height: 400px;
-  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
 }


### PR DESCRIPTION
## Summary

- **About** — stripped to hero, bio, credits, testimonials; removed duplicate bio paragraph and redundant "What I Do" section (covered by Services); full CSS rewrite with \`ab-*\` prefix and design tokens
- **FeaturedWork** — track data moved to module-level constant; duplicate \`dangerouslySetInnerHTML\` branches collapsed; filter buttons use \`aria-pressed\`; live count uses \`aria-live\`; full CSS rewrite with \`fw-*\` prefix
- **Success** — GitHub dark theme (\`#161b22\`, \`#238636\` hardcodes) replaced with warm neutral tokens; SVG check icon replaces text \`✓\`; all logic preserved (sessionId, hasConsultation, calendar embed); full CSS rewrite with \`succ-*\` prefix

## Test plan

- [ ] About renders hero, bio photo placeholder, credits list, and testimonials
- [ ] FeaturedWork filter buttons toggle platform correctly; \`aria-pressed\` updates; track count updates
- [ ] FeaturedWork Spotify and SoundCloud embeds render
- [ ] Success page: loading → no sessionId → error state; loading → sessionId present → confirmed state
- [ ] Success consultation branch shows Google Calendar embed
- [ ] Success non-consultation branch shows Next Steps list
- [ ] No horizontal scroll at 390px on any of the three pages
- [ ] No TypeScript errors (\`npm run build\` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)