### PR TITLE
Phase D v2: Beats page redesign (ui-ux-pro-max)

### DIFF
--- a/src/components/beats/BeatCard.tsx
+++ b/src/components/beats/BeatCard.tsx
@@ -99,6 +99,7 @@ const BeatCard: React.FC<BeatCardProps> = ({ beat, view = 'list' }) => {
       aria-label={beat.title}
     >
       <button
+        type="button"
         className="bcl-play-btn"
         onClick={handlePlayPause}
         disabled={!hasPreview}

--- a/src/components/beats/BeatFilters.tsx
+++ b/src/components/beats/BeatFilters.tsx
@@ -84,15 +84,20 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
         </div>
 
         <button
+          type="button"
           className={`bfb-more-btn${moreOpen ? ' open' : ''}`}
           onClick={() => setMoreOpen(prev => !prev)}
           aria-expanded={moreOpen}
+          aria-controls="bfb-more-panel"
         >
-          More Filters {moreOpen ? '▲' : '▼'}
+          More Filters
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ transform: moreOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s ease' }}>
+            <polyline points="2,4 6,8 10,4" />
+          </svg>
         </button>
 
         {hasActive && (
-          <button className="bfb-clear-btn" onClick={onClearFilters}>
+          <button type="button" className="bfb-clear-btn" onClick={onClearFilters}>
             Clear All
           </button>
         )}
@@ -100,7 +105,7 @@ const BeatFiltersComponent: React.FC<BeatFiltersProps> = ({
 
       {/* More Filters panel */}
       {moreOpen && (
-        <div className="bfb-more-panel">
+        <div id="bfb-more-panel" className="bfb-more-panel">
           <div className="bfb-more-group">
             <label htmlFor="bfb-key" className="bfb-label">Key</label>
             <select

--- a/src/pages/Beats.tsx
+++ b/src/pages/Beats.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import usePageMeta from '../hooks/usePageMeta';
 import '../styles/BeatsStyles.css';
 import BeatCard from '../components/beats/BeatCard';
@@ -7,12 +7,11 @@ import BeatFilters from '../components/beats/BeatFilters';
 import type { Beat, BeatFilters as BeatFiltersType } from '../types/beats';
 import beatsData from '../data/beats.json';
 
+const ALL_BEATS: Beat[] = beatsData.beats;
+
 const Beats: React.FC = () => {
-  const [beats, setBeats] = useState<Beat[]>([]);
-  const [filteredBeats, setFilteredBeats] = useState<Beat[]>([]);
   const [filters, setFilters] = useState<BeatFiltersType>({});
   const [view, setView] = useState<'list' | 'grid'>('list');
-  const [isLoading, setIsLoading] = useState(true);
 
   usePageMeta({
     title: 'Buy Beats | PRODBYRIQ',
@@ -20,145 +19,120 @@ const Beats: React.FC = () => {
     canonicalPath: '/beats',
   });
 
-  useEffect(() => {
-    setBeats(beatsData.beats);
-    setFilteredBeats(beatsData.beats);
-    setIsLoading(false);
-  }, []);
-
-  useEffect(() => {
-    let filtered = [...beats];
+  const filteredBeats = useMemo(() => {
+    let result = ALL_BEATS;
 
     if (filters.search) {
       const q = filters.search.toLowerCase();
-      filtered = filtered.filter(beat =>
-        beat.title.toLowerCase().includes(q) ||
-        beat.genres.some(g => g.toLowerCase().includes(q)) ||
-        beat.tags?.some(t => t.toLowerCase().includes(q)) ||
-        beat.mood?.some(m => m.toLowerCase().includes(q))
+      result = result.filter(b =>
+        b.title.toLowerCase().includes(q) ||
+        b.genres.some(g => g.toLowerCase().includes(q)) ||
+        b.tags?.some(t => t.toLowerCase().includes(q)) ||
+        b.mood?.some(m => m.toLowerCase().includes(q))
       );
     }
-
     if (filters.mood) {
-      filtered = filtered.filter(beat =>
-        beat.mood?.map(m => m.toLowerCase()).includes(filters.mood!.toLowerCase())
+      result = result.filter(b =>
+        b.mood?.map(m => m.toLowerCase()).includes(filters.mood!.toLowerCase())
       );
     }
-
     if (filters.genre) {
-      filtered = filtered.filter(beat => beat.genres.includes(filters.genre!));
+      result = result.filter(b => b.genres.includes(filters.genre!));
     }
-
     if (filters.key) {
-      filtered = filtered.filter(beat => beat.key === filters.key);
+      result = result.filter(b => b.key === filters.key);
     }
-
     if (filters.bpmMin !== undefined && !isNaN(filters.bpmMin)) {
-      filtered = filtered.filter(beat => beat.bpm >= filters.bpmMin!);
+      result = result.filter(b => b.bpm >= filters.bpmMin!);
     }
-
     if (filters.bpmMax !== undefined && !isNaN(filters.bpmMax)) {
-      filtered = filtered.filter(beat => beat.bpm <= filters.bpmMax!);
+      result = result.filter(b => b.bpm <= filters.bpmMax!);
     }
 
-    setFilteredBeats(filtered);
-  }, [beats, filters]);
-
-  const handleFiltersChange = (newFilters: BeatFiltersType) => setFilters(newFilters);
-  const handleClearFilters = () => setFilters({});
+    return result;
+  }, [filters]);
 
   const hasActiveFilters = Object.values(filters).some(v => v !== undefined && v !== '');
 
-  if (isLoading) {
-    return (
-      <div className="beats-page">
-        <div className="beats-loading">Loading beats…</div>
-      </div>
-    );
-  }
-
   return (
-    <div className="beats-page">
-      {/* Page header */}
-      <div className="beats-page-header">
-        <div className="beats-container">
-          <div className="beats-header-content">
+    <div className="bs-page">
+
+      {/* ── Page Header ──────────────────────────────────── */}
+      <header className="bs-header">
+        <div className="bs-container">
+          <div className="bs-header-row">
             <div>
               <h1>Beat Store</h1>
-              <p className="beats-header-sub">
-                {beats.length} beats &nbsp;·&nbsp; Instant download &nbsp;·&nbsp; WAV quality
+              <p className="bs-header-sub">
+                <span data-stat>{ALL_BEATS.length}</span> beats
+                &nbsp;·&nbsp; Instant download &nbsp;·&nbsp; WAV quality
               </p>
             </div>
-            {/* View toggle */}
-            <div className="beats-view-toggle" role="group" aria-label="View mode">
+            <div className="bs-view-toggle" role="group" aria-label="View mode">
               <button
-                className={`vtoggle-btn${view === 'list' ? ' active' : ''}`}
+                type="button"
+                className={`bs-vtoggle${view === 'list' ? ' bs-vtoggle--active' : ''}`}
                 onClick={() => setView('list')}
                 aria-pressed={view === 'list'}
-                title="List view"
+                aria-label="List view"
               >
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <line x1="8" y1="6" x2="21" y2="6"/>
-                  <line x1="8" y1="12" x2="21" y2="12"/>
-                  <line x1="8" y1="18" x2="21" y2="18"/>
-                  <line x1="3" y1="6" x2="3.01" y2="6"/>
-                  <line x1="3" y1="12" x2="3.01" y2="12"/>
-                  <line x1="3" y1="18" x2="3.01" y2="18"/>
+                  <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" />
+                  <line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
                 </svg>
               </button>
               <button
-                className={`vtoggle-btn${view === 'grid' ? ' active' : ''}`}
+                type="button"
+                className={`bs-vtoggle${view === 'grid' ? ' bs-vtoggle--active' : ''}`}
                 onClick={() => setView('grid')}
                 aria-pressed={view === 'grid'}
-                title="Grid view"
+                aria-label="Grid view"
               >
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <rect x="3" y="3" width="7" height="7"/>
-                  <rect x="14" y="3" width="7" height="7"/>
-                  <rect x="3" y="14" width="7" height="7"/>
-                  <rect x="14" y="14" width="7" height="7"/>
+                  <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" />
+                  <rect x="3" y="14" width="7" height="7" /><rect x="14" y="14" width="7" height="7" />
                 </svg>
               </button>
             </div>
           </div>
         </div>
-      </div>
+      </header>
 
-      {/* Filters */}
-      <div className="beats-filters-section">
-        <div className="beats-container">
+      {/* ── Filters ──────────────────────────────────────── */}
+      <div className="bs-filters-section">
+        <div className="bs-container">
           <BeatFilters
             filters={filters}
-            onFiltersChange={handleFiltersChange}
-            onClearFilters={handleClearFilters}
+            onFiltersChange={setFilters}
+            onClearFilters={() => setFilters({})}
           />
         </div>
       </div>
 
-      {/* Results */}
-      <div className="beats-results-section">
-        <div className="beats-container">
+      {/* ── Results ──────────────────────────────────────── */}
+      <div className="bs-results-section">
+        <div className="bs-container">
           {hasActiveFilters && (
-            <p className="beats-results-count">
-              {filteredBeats.length} result{filteredBeats.length !== 1 ? 's' : ''}
+            <p className="bs-results-count" aria-live="polite">
+              <span data-stat>{filteredBeats.length}</span> result{filteredBeats.length !== 1 ? 's' : ''}
             </p>
           )}
 
           {filteredBeats.length === 0 ? (
-            <div className="beats-empty">
+            <div className="bs-empty">
               <p>No beats match your filters.</p>
-              <button className="btn-secondary" onClick={handleClearFilters}>
+              <button type="button" className="btn-secondary" onClick={() => setFilters({})}>
                 Clear Filters
               </button>
             </div>
           ) : view === 'list' ? (
-            <div className="beats-list">
+            <div className="bs-list" role="list">
               {filteredBeats.map(beat => (
                 <BeatCard key={beat.beat_id} beat={beat} view="list" />
               ))}
             </div>
           ) : (
-            <div className="beats-grid">
+            <div className="bs-grid">
               {filteredBeats.map(beat => (
                 <BeatCard key={beat.beat_id} beat={beat} view="grid" />
               ))}
@@ -167,12 +141,13 @@ const Beats: React.FC = () => {
         </div>
       </div>
 
-      {/* Email capture */}
-      <div className="beats-email-section">
-        <div className="beats-container">
+      {/* ── Email Capture ─────────────────────────────────── */}
+      <div className="bs-email-section">
+        <div className="bs-container">
           <EmailCapture />
         </div>
       </div>
+
     </div>
   );
 };

--- a/src/styles/BeatsStyles.css
+++ b/src/styles/BeatsStyles.css
@@ -1,52 +1,46 @@
-.beats-page {
+/* ── Page Shell ─────────────────────────────────────────────── */
+.bs-page {
   width: 100%;
-  background-color: var(--bg-primary);
+  background: var(--bg-primary);
 }
 
-.beats-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 1.5rem;
+.bs-container {
+  max-width: var(--container-xl);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
 }
 
-/* ─── Page Header ────────────────────────────────────── */
-.beats-page-header {
-  background-color: var(--bg-primary);
-  padding: 3rem 0 1.5rem;
+/* ── Page Header ────────────────────────────────────────────── */
+.bs-header {
+  background: var(--bg-primary);
+  padding: var(--space-12) 0 var(--space-6);
   border-bottom: 1px solid var(--border-default);
 }
 
-.beats-header-content {
+.bs-header-row {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
-.beats-page-header h1 {
+.bs-header h1 {
   font-family: var(--font-display);
-  font-size: 2.5rem;
+  font-size: var(--text-5xl);
   font-weight: 700;
   color: var(--text-heading);
-  margin-bottom: 0.375rem;
+  margin-bottom: var(--space-2);
 }
 
-.beats-header-sub {
-  font-family: var(--font-body);
-  font-size: 0.875rem;
+.bs-header-sub {
+  font-size: var(--text-sm);
   color: var(--text-secondary);
   margin: 0;
+  font-feature-settings: "tnum" 1;
 }
 
-.beats-loading {
-  padding: 6rem 2rem;
-  text-align: center;
-  color: var(--text-secondary);
-  font-family: var(--font-body);
-}
-
-/* ─── View Toggle ────────────────────────────────────── */
-.beats-view-toggle {
+/* ── View Toggle ────────────────────────────────────────────── */
+.bs-view-toggle {
   display: flex;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -54,43 +48,52 @@
   flex-shrink: 0;
 }
 
-.vtoggle-btn {
+.bs-vtoggle {
   background: transparent;
   border: none;
   border-radius: 0;
   color: var(--text-muted);
-  padding: 0.5rem 0.75rem;
+  padding: 0 var(--space-3);
+  min-height: 40px;
+  min-width: 40px;
   cursor: pointer;
   display: flex;
   align-items: center;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  justify-content: center;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
 }
 
-.vtoggle-btn:hover {
+.bs-vtoggle:hover {
   background: var(--accent-glow);
   color: var(--accent-primary);
   transform: none;
+  box-shadow: none;
 }
 
-.vtoggle-btn.active {
+.bs-vtoggle--active {
   background: var(--accent-primary);
   color: #FFFFFF;
 }
 
-.vtoggle-btn + .vtoggle-btn {
+.bs-vtoggle + .bs-vtoggle {
   border-left: 1px solid var(--border-default);
 }
 
-/* ─── Filters Bar ────────────────────────────────────── */
-.beats-filters-section {
-  padding: 1.5rem 0 0;
-  background-color: var(--bg-primary);
+.bs-vtoggle:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: -2px;
+}
+
+/* ── Filters Bar ────────────────────────────────────────────── */
+.bs-filters-section {
+  padding: var(--space-6) 0 0;
+  background: var(--bg-primary);
 }
 
 .beat-filters-bar {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .bfb-search-wrap {
@@ -100,7 +103,7 @@
 
 .bfb-search-icon {
   position: absolute;
-  left: 0.875rem;
+  left: var(--space-3);
   top: 50%;
   transform: translateY(-50%);
   color: var(--text-muted);
@@ -109,19 +112,20 @@
 
 .bfb-search {
   width: 100%;
-  padding: 0.625rem 1rem 0.625rem 2.5rem;
+  padding: 0.625rem var(--space-4) 0.625rem 2.5rem;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  font-size: 0.9375rem;
+  font-size: var(--text-base);
   font-family: var(--font-body);
   color: var(--text-primary);
-  transition: border-color var(--transition-default), box-shadow var(--transition-default);
+  min-height: 44px;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .bfb-search:focus {
   outline: none;
-  border-color: var(--border-strong);
+  border-color: var(--border-focus);
   box-shadow: 0 0 0 3px var(--accent-glow);
 }
 
@@ -129,7 +133,7 @@
 .bfb-pills-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--space-2);
   align-items: center;
 }
 
@@ -137,13 +141,14 @@
   background: transparent;
   border: 1px solid var(--border-default);
   color: var(--text-secondary);
-  padding: 0.375rem 0.875rem;
-  border-radius: 50px;
-  font-size: 0.8125rem;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
   font-weight: 500;
   font-family: var(--font-body);
+  min-height: 36px;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .bfb-pill:hover {
@@ -151,6 +156,7 @@
   color: var(--accent-primary);
   background: var(--accent-glow);
   transform: none;
+  box-shadow: none;
 }
 
 .bfb-pill.active {
@@ -159,22 +165,27 @@
   color: #FFFFFF;
 }
 
+.bfb-pill:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
 /* Bottom row */
 .bfb-bottom-row {
   display: flex;
-  align-items: center;
-  gap: 1rem;
+  align-items: flex-end;
+  gap: var(--space-4);
   flex-wrap: wrap;
 }
 
 .bfb-label {
   font-family: var(--font-body);
-  font-size: 0.8125rem;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: 700;
   color: var(--text-secondary);
   text-transform: uppercase;
-  letter-spacing: 0.75px;
-  margin-bottom: 0.375rem;
+  letter-spacing: 0.08em;
+  margin-bottom: var(--space-1);
   display: block;
 }
 
@@ -184,71 +195,82 @@
 }
 
 .bfb-select {
-  padding: 0.5rem 2rem 0.5rem 0.875rem;
+  padding: var(--space-2) 2.25rem var(--space-2) var(--space-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--text-primary);
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-family: var(--font-body);
+  min-height: 40px;
   cursor: pointer;
+  -webkit-appearance: none;
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L6 7L11 1' stroke='%238B7355' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 0.75rem center;
   width: 160px;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .bfb-select:focus {
   outline: none;
-  border-color: var(--border-strong);
+  border-color: var(--border-focus);
   box-shadow: 0 0 0 3px var(--accent-glow);
 }
 
 .bfb-more-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
   background: transparent;
   border: 1px solid var(--border-default);
   color: var(--text-secondary);
-  padding: 0.5rem 0.875rem;
+  padding: var(--space-2) var(--space-3);
+  min-height: 40px;
   border-radius: var(--radius-md);
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   font-family: var(--font-body);
   cursor: pointer;
-  transition: all var(--transition-fast);
-  align-self: flex-end;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
-.bfb-more-btn:hover, .bfb-more-btn.open {
+.bfb-more-btn:hover,
+.bfb-more-btn.open {
   border-color: var(--accent-primary);
   color: var(--accent-primary);
   background: var(--accent-glow);
   transform: none;
+  box-shadow: none;
 }
 
 .bfb-clear-btn {
+  display: inline-flex;
+  align-items: center;
   background: transparent;
   border: 1px solid var(--error);
   color: var(--error);
-  padding: 0.5rem 0.875rem;
+  padding: var(--space-2) var(--space-3);
+  min-height: 40px;
   border-radius: var(--radius-md);
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   font-family: var(--font-body);
   cursor: pointer;
-  transition: all var(--transition-fast);
-  align-self: flex-end;
+  transition: background-color var(--transition-fast);
 }
 
 .bfb-clear-btn:hover {
   background: rgba(184, 92, 92, 0.08);
   transform: none;
+  box-shadow: none;
 }
 
 .bfb-more-panel {
   display: flex;
-  gap: 2rem;
-  padding: 1.25rem;
+  gap: var(--space-8);
+  padding: var(--space-5);
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -258,58 +280,65 @@
 .bfb-more-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .bfb-bpm-inputs {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .bfb-bpm-input {
   width: 80px;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-family: var(--font-body);
   color: var(--text-primary);
   background: var(--bg-elevated);
+  min-height: 40px;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.bfb-bpm-input:focus {
+  outline: none;
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px var(--accent-glow);
 }
 
 .bfb-bpm-sep {
   color: var(--text-muted);
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
 }
 
-/* ─── Results ────────────────────────────────────────── */
-.beats-results-section {
-  padding: 1.5rem 0 3rem;
+/* ── Results ────────────────────────────────────────────────── */
+.bs-results-section {
+  padding: var(--space-6) 0 var(--space-16);
 }
 
-.beats-results-count {
-  font-family: var(--font-body);
-  font-size: 0.875rem;
+.bs-results-count {
+  font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
+  font-feature-settings: "tnum" 1;
 }
 
-.beats-empty {
-  padding: 4rem 2rem;
+.bs-empty {
+  padding: var(--space-16) var(--space-8);
   text-align: center;
 }
 
-.beats-empty p {
+.bs-empty p {
   color: var(--text-secondary);
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
 }
 
-/* ─── List View ──────────────────────────────────────── */
-.beats-list {
+/* ── List View ──────────────────────────────────────────────── */
+.bs-list {
   display: flex;
   flex-direction: column;
-  gap: 0;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   overflow: hidden;
@@ -319,10 +348,10 @@
 .beat-card-list {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.875rem 1.25rem;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-5);
   border-bottom: 1px solid var(--border-default);
-  transition: background var(--transition-fast);
+  transition: background-color var(--transition-fast);
   position: relative;
 }
 
@@ -336,9 +365,10 @@
 }
 
 .bcl-play-btn {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  border-radius: var(--radius-full);
   background: var(--accent-primary);
   border: none;
   color: #FFFFFF;
@@ -347,13 +377,19 @@
   justify-content: center;
   cursor: pointer;
   flex-shrink: 0;
-  transition: all var(--transition-fast);
+  transition: background-color var(--transition-fast), transform 0.1s var(--ease-spring);
   padding: 0;
 }
 
 .bcl-play-btn:hover {
   background: var(--accent-hover);
-  transform: scale(1.05);
+  transform: scale(1.06);
+  box-shadow: var(--shadow-sm);
+}
+
+.bcl-play-btn:active {
+  transform: scale(0.95);
+  transition-duration: 0.07s;
 }
 
 .bcl-play-btn:disabled {
@@ -361,6 +397,12 @@
   color: var(--text-muted);
   cursor: not-allowed;
   transform: none;
+  box-shadow: none;
+}
+
+.bcl-play-btn:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
 }
 
 .bcl-cover {
@@ -378,29 +420,27 @@
 
 .bcl-title {
   display: block;
-  font-family: var(--font-body);
-  font-size: 0.9375rem;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-heading);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
 }
 
 .bcl-tags {
   display: flex;
-  gap: 0.375rem;
+  gap: var(--space-1);
   flex-wrap: wrap;
 }
 
 .bcl-tag {
-  font-size: 0.6875rem;
-  font-family: var(--font-body);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   background: var(--almond);
-  padding: 0.125rem 0.5rem;
-  border-radius: 50px;
+  padding: 0.125rem var(--space-2);
+  border-radius: var(--radius-full);
 }
 
 .bcl-tag-mood {
@@ -412,20 +452,23 @@
 
 .bcl-meta {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--space-3);
   align-items: center;
   flex-shrink: 0;
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
+  font-feature-settings: "tnum" 1;
 }
 
-.bcl-bpm { font-weight: 600; color: var(--text-primary); }
+.bcl-bpm {
+  font-weight: 600;
+  color: var(--text-primary);
+}
 
-/* ─── Buy Buttons ────────────────────────────────────── */
+/* ── Buy Buttons ────────────────────────────────────────────── */
 .beat-buy-btns {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
   flex-shrink: 0;
 }
 
@@ -433,14 +476,16 @@
   background: transparent;
   border: 1.5px solid var(--accent-primary);
   color: var(--accent-primary);
-  padding: 0.4375rem 0.875rem;
+  padding: var(--space-2) var(--space-3);
+  min-height: 36px;
   border-radius: var(--radius-md);
-  font-size: 0.8125rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   font-family: var(--font-body);
   cursor: pointer;
   white-space: nowrap;
-  transition: all var(--transition-fast);
+  font-feature-settings: "tnum" 1;
+  transition: background-color var(--transition-fast), color var(--transition-fast), transform 0.1s var(--ease-spring);
 }
 
 .beat-btn-lease:hover {
@@ -449,18 +494,25 @@
   transform: translateY(-1px);
 }
 
+.beat-btn-lease:active {
+  transform: scale(0.97);
+  transition-duration: 0.07s;
+}
+
 .beat-btn-exclusive {
   background: var(--accent-primary);
   border: 1.5px solid var(--accent-primary);
   color: #FFFFFF;
-  padding: 0.4375rem 0.875rem;
+  padding: var(--space-2) var(--space-3);
+  min-height: 36px;
   border-radius: var(--radius-md);
-  font-size: 0.8125rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   font-family: var(--font-body);
   cursor: pointer;
   white-space: nowrap;
-  transition: all var(--transition-fast);
+  font-feature-settings: "tnum" 1;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), transform 0.1s var(--ease-spring);
 }
 
 .beat-btn-exclusive:hover {
@@ -469,11 +521,16 @@
   transform: translateY(-1px);
 }
 
-/* ─── Grid View ──────────────────────────────────────── */
-.beats-grid {
+.beat-btn-exclusive:active {
+  transform: scale(0.97);
+  transition-duration: 0.07s;
+}
+
+/* ── Grid View ──────────────────────────────────────────────── */
+.bs-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
+  gap: var(--space-5);
 }
 
 .beat-card-grid {
@@ -482,20 +539,30 @@
   border-radius: var(--radius-lg);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
-  transition: box-shadow var(--transition-default), transform var(--transition-default);
+  transition:
+    box-shadow var(--transition-default),
+    border-color var(--transition-default),
+    transform var(--transition-slow);
 }
 
 .beat-card-grid:hover,
 .beat-card-grid.is-playing {
   box-shadow: var(--shadow-lg);
-  transform: translateY(-2px);
+  border-color: var(--border-strong);
+  transform: translateY(-3px);
 }
 
 .bcg-cover {
   position: relative;
   aspect-ratio: 1;
   overflow: hidden;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
   cursor: pointer;
+  display: block;
 }
 
 .bcg-cover img {
@@ -503,6 +570,7 @@
   height: 100%;
   object-fit: cover;
   transition: transform var(--transition-slow);
+  display: block;
 }
 
 .beat-card-grid:hover .bcg-cover img {
@@ -526,15 +594,14 @@
 }
 
 .bcg-info {
-  padding: 1rem;
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .bcg-title {
-  font-family: var(--font-body);
-  font-size: 0.9375rem;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-heading);
   margin: 0;
@@ -544,30 +611,34 @@
 }
 
 .bcg-meta {
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   display: flex;
-  gap: 0.375rem;
+  gap: var(--space-1);
   flex-wrap: wrap;
+  font-feature-settings: "tnum" 1;
 }
 
-/* ─── Email section ──────────────────────────────────── */
-.beats-email-section {
-  background-color: var(--almond);
-  padding: 4rem 0;
+/* ── Email Section ──────────────────────────────────────────── */
+.bs-email-section {
+  background: var(--almond);
+  padding: var(--space-20) 0;
 }
 
-/* ─── Responsive ─────────────────────────────────────── */
+/* ── Responsive ─────────────────────────────────────────────── */
 @media (max-width: 900px) {
-  .beats-grid {
+  .bs-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (max-width: 768px) {
-  .beats-page-header {
-    padding: 2rem 0 1rem;
+  .bs-header {
+    padding: var(--space-8) 0 var(--space-4);
+  }
+
+  .bs-container {
+    padding-inline: var(--space-4);
   }
 
   .bcl-meta {
@@ -575,29 +646,23 @@
   }
 
   .bfb-pills-row {
-    gap: 0.375rem;
+    gap: var(--space-1);
   }
 }
 
 @media (max-width: 640px) {
-  .beats-grid {
+  .bs-grid {
     grid-template-columns: 1fr;
   }
 
-  .beats-header-content {
+  .bs-header-row {
     flex-direction: column;
     align-items: flex-start;
   }
 
   .beat-buy-btns {
     flex-direction: column;
-    gap: 0.375rem;
-  }
-
-  .beat-btn-lease,
-  .beat-btn-exclusive {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.75rem;
+    gap: var(--space-1);
   }
 
   .bcl-cover {
@@ -606,6 +671,11 @@
 
   .bfb-more-panel {
     flex-direction: column;
-    gap: 1rem;
+    gap: var(--space-4);
   }
+}
+
+/* ── Reduced Motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .bs-page * { transition: none !important; }
 }


### PR DESCRIPTION
## Summary
- Full redesign of `Beats.tsx`, `BeatsStyles.css`, `BeatCard.tsx`, and `BeatFilters.tsx`

## Key changes
- `bs-*` scoped page prefix in CSS and JSX
- Removed `isLoading`/`useEffect` anti-pattern — beats.json is synchronous; `filteredBeats` now computed with `useMemo`
- `bcl-play-btn`: raised to 44×44px (was 36px) to meet touch-target standard
- `▲`/`▼` text in More Filters replaced with animated SVG chevron
- `aria-controls`, `type="button"`, `role="list"` accessibility improvements
- 8pt spacing token system throughout, `font-feature-settings: tnum` on prices/BPM
- Spring easing on interactive elements; `prefers-reduced-motion` scoped

## Test plan
- [ ] Beat list and grid views render correctly
- [ ] Search, mood pills, genre select, and BPM range filters all work
- [ ] Play/pause buttons work with 44px touch area
- [ ] Mobile collapses to single column; meta row hides on small screens
- [ ] Email capture section renders at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)