### PR TITLE
feat(admin): Phase F — Beat Upload Portal (ui-ux-pro-max Dark Mode OLED)

### DIFF
--- a/src/components/BeatUpload.tsx
+++ b/src/components/BeatUpload.tsx
@@ -1,0 +1,473 @@
+import React, { useState, useRef, KeyboardEvent } from 'react';
+import { GENRES, MOODS, KEYS } from '../types/beats';
+
+interface BeatFormData {
+  title: string;
+  bpm: string;
+  key: string;
+  genres: string[];
+  mood: string[];
+  tags: string[];
+  lease_price: string;
+  exclusive_price: string;
+  preview_path: string;
+  full_path: string;
+  cover_path: string;
+  google_drive_file_id: string;
+  google_drive_cover_id: string;
+}
+
+interface FormErrors {
+  title?: string;
+  bpm?: string;
+  key?: string;
+  genres?: string;
+  preview_path?: string;
+  full_path?: string;
+  cover_path?: string;
+}
+
+const EMPTY_FORM: BeatFormData = {
+  title: '',
+  bpm: '',
+  key: '',
+  genres: [],
+  mood: [],
+  tags: [],
+  lease_price: '50',
+  exclusive_price: '200',
+  preview_path: '',
+  full_path: '',
+  cover_path: '',
+  google_drive_file_id: '',
+  google_drive_cover_id: '',
+};
+
+const IconCheck = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const IconCopy = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+const generateBeatId = (title: string): string => {
+  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+  return `beat_${slug}_${Date.now().toString(36)}`;
+};
+
+const validate = (form: BeatFormData): FormErrors => {
+  const errors: FormErrors = {};
+  if (!form.title.trim()) errors.title = 'Title is required';
+  const bpm = parseInt(form.bpm);
+  if (!form.bpm || isNaN(bpm) || bpm < 40 || bpm > 250) errors.bpm = 'Enter a valid BPM (40–250)';
+  if (!form.key) errors.key = 'Key is required';
+  if (form.genres.length === 0) errors.genres = 'Select at least one genre';
+  if (!form.preview_path.trim()) errors.preview_path = 'Preview URL is required';
+  if (!form.full_path.trim()) errors.full_path = 'Full track URL is required';
+  if (!form.cover_path.trim()) errors.cover_path = 'Cover path is required';
+  return errors;
+};
+
+const BeatUpload: React.FC = () => {
+  const [form, setForm] = useState<BeatFormData>(EMPTY_FORM);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [touched, setTouched] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [generatedJson, setGeneratedJson] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [tagInput, setTagInput] = useState('');
+  const tagInputRef = useRef<HTMLInputElement>(null);
+
+  const set = (field: keyof BeatFormData, value: BeatFormData[keyof BeatFormData]) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+  };
+
+  const touch = (field: string) => {
+    setTouched(prev => new Set(prev).add(field));
+    const errs = validate({ ...form });
+    setErrors(errs);
+  };
+
+  const toggleCheckbox = (field: 'genres' | 'mood', value: string) => {
+    set(field, form[field].includes(value)
+      ? form[field].filter(v => v !== value)
+      : [...form[field], value]
+    );
+  };
+
+  const addTag = (raw: string) => {
+    const tag = raw.trim().toLowerCase().replace(/\s+/g, '_');
+    if (tag && !form.tags.includes(tag)) {
+      set('tags', [...form.tags, tag]);
+    }
+    setTagInput('');
+  };
+
+  const removeTag = (tag: string) => {
+    set('tags', form.tags.filter(t => t !== tag));
+  };
+
+  const handleTagKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag(tagInput);
+    } else if (e.key === 'Backspace' && !tagInput && form.tags.length > 0) {
+      set('tags', form.tags.slice(0, -1));
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const allFields = ['title', 'bpm', 'key', 'genres', 'preview_path', 'full_path', 'cover_path'];
+    setTouched(new Set(allFields));
+    const errs = validate(form);
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+
+    setSubmitting(true);
+    await new Promise(r => setTimeout(r, 400));
+
+    const entry = {
+      beat_id: generateBeatId(form.title),
+      title: form.title.trim(),
+      bpm: parseInt(form.bpm),
+      key: form.key,
+      genres: form.genres,
+      preview_path: form.preview_path.trim(),
+      full_path: form.full_path.trim(),
+      cover_path: form.cover_path.trim(),
+      lease_price: parseInt(form.lease_price) || 50,
+      exclusive_price: parseInt(form.exclusive_price) || 200,
+      created_at: new Date().toISOString().split('T')[0],
+      ...(form.tags.length > 0 && { tags: form.tags }),
+      ...(form.mood.length > 0 && { mood: form.mood }),
+      ...(form.google_drive_file_id.trim() && { google_drive_file_id: form.google_drive_file_id.trim() }),
+      ...(form.google_drive_cover_id.trim() && { google_drive_cover_id: form.google_drive_cover_id.trim() }),
+    };
+
+    setGeneratedJson(JSON.stringify(entry, null, 2));
+    setSubmitting(false);
+  };
+
+  const handleCopy = async () => {
+    if (!generatedJson) return;
+    await navigator.clipboard.writeText(generatedJson);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleReset = () => {
+    setForm(EMPTY_FORM);
+    setErrors({});
+    setTouched(new Set());
+    setGeneratedJson(null);
+    setCopied(false);
+    setTagInput('');
+  };
+
+  const showError = (field: string) => touched.has(field) ? errors[field as keyof FormErrors] : undefined;
+
+  return (
+    <form className="bu-form" onSubmit={handleSubmit} noValidate aria-label="Add new beat">
+
+      {/* Basic info */}
+      <section className="bu-section" aria-labelledby="bu-basics-heading">
+        <p className="bu-section-title" id="bu-basics-heading">Beat Info</p>
+        <div className="bu-row">
+          <div className="bu-field">
+            <label htmlFor="bu-title" className="bu-label bu-label-required">Title</label>
+            <input
+              id="bu-title"
+              type="text"
+              className={`bu-input${showError('title') ? ' bu-input--error' : ''}`}
+              value={form.title}
+              onChange={e => set('title', e.target.value)}
+              onBlur={() => touch('title')}
+              autoComplete="off"
+              aria-required="true"
+              aria-describedby={showError('title') ? 'bu-title-err' : undefined}
+            />
+            {showError('title') && <span id="bu-title-err" className="bu-field-error" role="alert">{showError('title')}</span>}
+          </div>
+
+          <div className="bu-field">
+            <label htmlFor="bu-bpm" className="bu-label bu-label-required">BPM</label>
+            <input
+              id="bu-bpm"
+              type="number"
+              className={`bu-input${showError('bpm') ? ' bu-input--error' : ''}`}
+              value={form.bpm}
+              onChange={e => set('bpm', e.target.value)}
+              onBlur={() => touch('bpm')}
+              min={40}
+              max={250}
+              aria-required="true"
+              aria-describedby={showError('bpm') ? 'bu-bpm-err' : undefined}
+            />
+            {showError('bpm') && <span id="bu-bpm-err" className="bu-field-error" role="alert">{showError('bpm')}</span>}
+          </div>
+        </div>
+
+        <div className="bu-row">
+          <div className="bu-field">
+            <label htmlFor="bu-key" className="bu-label bu-label-required">Key</label>
+            <select
+              id="bu-key"
+              className={`bu-select${showError('key') ? ' bu-select--error' : ''}`}
+              value={form.key}
+              onChange={e => set('key', e.target.value)}
+              onBlur={() => touch('key')}
+              aria-required="true"
+              aria-describedby={showError('key') ? 'bu-key-err' : undefined}
+            >
+              <option value="">Select key…</option>
+              {KEYS.map(k => <option key={k} value={k}>{k}</option>)}
+            </select>
+            {showError('key') && <span id="bu-key-err" className="bu-field-error" role="alert">{showError('key')}</span>}
+          </div>
+
+          <div className="bu-field">
+            <label htmlFor="bu-lease" className="bu-label">Lease Price ($)</label>
+            <input
+              id="bu-lease"
+              type="number"
+              className="bu-input"
+              value={form.lease_price}
+              onChange={e => set('lease_price', e.target.value)}
+              min={0}
+            />
+          </div>
+        </div>
+
+        <div className="bu-row">
+          <div className="bu-field">
+            <label htmlFor="bu-excl" className="bu-label">Exclusive Price ($)</label>
+            <input
+              id="bu-excl"
+              type="number"
+              className="bu-input"
+              value={form.exclusive_price}
+              onChange={e => set('exclusive_price', e.target.value)}
+              min={0}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Genres */}
+      <section className="bu-section" aria-labelledby="bu-genres-heading">
+        <p className="bu-section-title" id="bu-genres-heading">Genres & Mood</p>
+        <div className="bu-field">
+          <p className="bu-label bu-label-required" id="bu-genres-label">Genres</p>
+          <div
+            className="bu-checkbox-group"
+            role="group"
+            aria-labelledby="bu-genres-label"
+            onBlur={() => touch('genres')}
+          >
+            {GENRES.map(g => (
+              <label
+                key={g}
+                className={`bu-checkbox-pill${form.genres.includes(g) ? ' bu-checkbox-pill--checked' : ''}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={form.genres.includes(g)}
+                  onChange={() => toggleCheckbox('genres', g)}
+                  aria-label={g}
+                />
+                {form.genres.includes(g) && <IconCheck />}
+                {g}
+              </label>
+            ))}
+          </div>
+          {showError('genres') && <span className="bu-field-error" role="alert">{showError('genres')}</span>}
+        </div>
+
+        <div className="bu-field">
+          <p className="bu-label" id="bu-mood-label">Mood</p>
+          <div className="bu-checkbox-group" role="group" aria-labelledby="bu-mood-label">
+            {MOODS.map(m => (
+              <label
+                key={m}
+                className={`bu-checkbox-pill${form.mood.includes(m) ? ' bu-checkbox-pill--checked' : ''}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={form.mood.includes(m)}
+                  onChange={() => toggleCheckbox('mood', m)}
+                  aria-label={m}
+                />
+                {form.mood.includes(m) && <IconCheck />}
+                {m}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="bu-field">
+          <label htmlFor="bu-tag-input" className="bu-label">Tags</label>
+          <div
+            className="bu-tags-wrap"
+            onClick={() => tagInputRef.current?.focus()}
+            aria-label="Tags input"
+          >
+            {form.tags.map(tag => (
+              <span key={tag} className="bu-tag-chip">
+                {tag}
+                <button
+                  type="button"
+                  className="bu-tag-remove"
+                  onClick={e => { e.stopPropagation(); removeTag(tag); }}
+                  aria-label={`Remove tag ${tag}`}
+                >×</button>
+              </span>
+            ))}
+            <input
+              id="bu-tag-input"
+              ref={tagInputRef}
+              type="text"
+              className="bu-tag-input"
+              value={tagInput}
+              onChange={e => setTagInput(e.target.value)}
+              onKeyDown={handleTagKeyDown}
+              onBlur={() => { if (tagInput.trim()) addTag(tagInput); }}
+              placeholder={form.tags.length === 0 ? 'Type and press Enter or comma…' : ''}
+              aria-label="Add tag"
+            />
+          </div>
+          <span className="bu-helper">Press Enter or comma to add. Backspace removes the last tag.</span>
+        </div>
+      </section>
+
+      {/* File paths */}
+      <section className="bu-section" aria-labelledby="bu-files-heading">
+        <p className="bu-section-title" id="bu-files-heading">File URLs</p>
+
+        <div className="bu-field bu-field--full">
+          <label htmlFor="bu-preview" className="bu-label bu-label-required">Preview URL (S3 / CDN)</label>
+          <input
+            id="bu-preview"
+            type="url"
+            className={`bu-input${showError('preview_path') ? ' bu-input--error' : ''}`}
+            value={form.preview_path}
+            onChange={e => set('preview_path', e.target.value)}
+            onBlur={() => touch('preview_path')}
+            placeholder="https://bucket.s3.region.amazonaws.com/previews/…"
+            autoComplete="off"
+            aria-required="true"
+            aria-describedby={showError('preview_path') ? 'bu-preview-err' : undefined}
+          />
+          {showError('preview_path') && <span id="bu-preview-err" className="bu-field-error" role="alert">{showError('preview_path')}</span>}
+        </div>
+
+        <div className="bu-field bu-field--full">
+          <label htmlFor="bu-full" className="bu-label bu-label-required">Full Track URL (S3 / CDN)</label>
+          <input
+            id="bu-full"
+            type="url"
+            className={`bu-input${showError('full_path') ? ' bu-input--error' : ''}`}
+            value={form.full_path}
+            onChange={e => set('full_path', e.target.value)}
+            onBlur={() => touch('full_path')}
+            placeholder="https://bucket.s3.region.amazonaws.com/full_tracks/…"
+            autoComplete="off"
+            aria-required="true"
+            aria-describedby={showError('full_path') ? 'bu-full-err' : undefined}
+          />
+          {showError('full_path') && <span id="bu-full-err" className="bu-field-error" role="alert">{showError('full_path')}</span>}
+        </div>
+
+        <div className="bu-field bu-field--full">
+          <label htmlFor="bu-cover" className="bu-label bu-label-required">Cover Path</label>
+          <input
+            id="bu-cover"
+            type="text"
+            className={`bu-input${showError('cover_path') ? ' bu-input--error' : ''}`}
+            value={form.cover_path}
+            onChange={e => set('cover_path', e.target.value)}
+            onBlur={() => touch('cover_path')}
+            placeholder="/covers/cover017.png"
+            autoComplete="off"
+            aria-required="true"
+            aria-describedby={showError('cover_path') ? 'bu-cover-err' : undefined}
+          />
+          {showError('cover_path') && <span id="bu-cover-err" className="bu-field-error" role="alert">{showError('cover_path')}</span>}
+        </div>
+      </section>
+
+      {/* Google Drive (optional) */}
+      <section className="bu-section" aria-labelledby="bu-drive-heading">
+        <p className="bu-section-title" id="bu-drive-heading">Google Drive IDs (optional)</p>
+        <div className="bu-row">
+          <div className="bu-field">
+            <label htmlFor="bu-gd-file" className="bu-label">Drive File ID</label>
+            <input
+              id="bu-gd-file"
+              type="text"
+              className="bu-input"
+              value={form.google_drive_file_id}
+              onChange={e => set('google_drive_file_id', e.target.value)}
+              placeholder="1aBcD…"
+              autoComplete="off"
+            />
+          </div>
+          <div className="bu-field">
+            <label htmlFor="bu-gd-cover" className="bu-label">Drive Cover ID</label>
+            <input
+              id="bu-gd-cover"
+              type="text"
+              className="bu-input"
+              value={form.google_drive_cover_id}
+              onChange={e => set('google_drive_cover_id', e.target.value)}
+              placeholder="1xYz…"
+              autoComplete="off"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Actions */}
+      <div className="bu-actions">
+        <button
+          type="submit"
+          className="bu-submit-btn"
+          disabled={submitting}
+          aria-busy={submitting}
+        >
+          {submitting ? 'Generating…' : 'Generate JSON Entry'}
+        </button>
+        <button type="button" className="bu-reset-btn" onClick={handleReset}>
+          Reset Form
+        </button>
+      </div>
+
+      {/* Generated JSON output */}
+      {generatedJson && (
+        <div className="bu-success-banner" role="status" aria-live="polite">
+          <span className="bu-success-icon"><IconCheck /></span>
+          <div className="bu-success-text">
+            <strong>JSON entry ready</strong>
+            Copy and paste this into <code>src/data/beats.json</code> inside the <code>"beats"</code> array.
+            <pre className="bu-json-block">{generatedJson}</pre>
+            <button
+              type="button"
+              className={`bu-copy-btn${copied ? ' bu-copy-btn--copied' : ''}`}
+              onClick={handleCopy}
+            >
+              <IconCopy />
+              {copied ? 'Copied!' : 'Copy to clipboard'}
+            </button>
+          </div>
+        </div>
+      )}
+    </form>
+  );
+};
+
+export default BeatUpload;

--- a/src/components/BeatUpload.tsx
+++ b/src/components/BeatUpload.tsx
@@ -80,6 +80,7 @@ const BeatUpload: React.FC = () => {
   const [submitting, setSubmitting] = useState(false);
   const [generatedJson, setGeneratedJson] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const [tagInput, setTagInput] = useState('');
   const tagInputRef = useRef<HTMLInputElement>(null);
 
@@ -141,8 +142,8 @@ const BeatUpload: React.FC = () => {
       preview_path: form.preview_path.trim(),
       full_path: form.full_path.trim(),
       cover_path: form.cover_path.trim(),
-      lease_price: parseInt(form.lease_price) || 50,
-      exclusive_price: parseInt(form.exclusive_price) || 200,
+      lease_price: !isNaN(parseInt(form.lease_price)) ? parseInt(form.lease_price) : 50,
+      exclusive_price: !isNaN(parseInt(form.exclusive_price)) ? parseInt(form.exclusive_price) : 200,
       created_at: new Date().toISOString().split('T')[0],
       ...(form.tags.length > 0 && { tags: form.tags }),
       ...(form.mood.length > 0 && { mood: form.mood }),
@@ -156,9 +157,15 @@ const BeatUpload: React.FC = () => {
 
   const handleCopy = async () => {
     if (!generatedJson) return;
-    await navigator.clipboard.writeText(generatedJson);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    setCopyError(false);
+    try {
+      await navigator.clipboard.writeText(generatedJson);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopyError(true);
+      setTimeout(() => setCopyError(false), 3000);
+    }
   };
 
   const handleReset = () => {
@@ -459,9 +466,10 @@ const BeatUpload: React.FC = () => {
               type="button"
               className={`bu-copy-btn${copied ? ' bu-copy-btn--copied' : ''}`}
               onClick={handleCopy}
+              aria-label="Copy JSON to clipboard"
             >
               <IconCopy />
-              {copied ? 'Copied!' : 'Copy to clipboard'}
+              {copied ? 'Copied!' : copyError ? 'Copy failed — select manually' : 'Copy to clipboard'}
             </button>
           </div>
         </div>

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -85,8 +85,9 @@ const GoogleDriveUpload: React.FC<GoogleDriveUploadProps> = ({ onFileLinked }) =
             Connect Google Drive
           </button>
           <p className="gd-note">
-            Connecting Google Drive allows you to link audio files and cover art directly from your Drive.
-            OAuth authentication is required — you will be redirected to Google to authorize access.
+            This is a placeholder connection state — no OAuth redirect or Google authentication is
+            performed yet. Use this to prepare Drive file IDs for the upload form. Full OAuth integration
+            requires a server-side implementation.
           </p>
         </>
       ) : (

--- a/src/components/GoogleDriveUpload.tsx
+++ b/src/components/GoogleDriveUpload.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+
+interface GoogleDriveUploadProps {
+  onFileLinked?: (fileId: string, fileName: string) => void;
+}
+
+const IconDrive = () => (
+  <svg width="18" height="18" viewBox="0 0 87.3 78" fill="none" aria-hidden="true">
+    <path d="M6.6 66.85 3.3 72.55C2.16 74.5 3.54 77 5.8 77h75.7c2.26 0 3.64-2.5 2.5-4.45l-3.3-5.7H6.6z" fill="#3772FF"/>
+    <path d="M29.15 5.5 1.9 53.3l4.7 8.1L35.4 13 29.15 5.5z" fill="#2AB7CA"/>
+    <path d="M85.4 61.4 58.15 13 51.9 5.5 35.4 13l19.35 33.5 26.35-8.85 4.3 13.75z" fill="#F9C74F"/>
+    <path d="M58.15 13 51.9 5.5 29.15 5.5 35.4 13h22.75z" fill="#43AA8B"/>
+    <path d="M6.6 66.85h73.8l-4.3-13.75-36.7 12.3-7.05 1.45H6.6z" fill="#90BE6D"/>
+  </svg>
+);
+
+const IconLink = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </svg>
+);
+
+const GoogleDriveUpload: React.FC<GoogleDriveUploadProps> = ({ onFileLinked }) => {
+  const [connected, setConnected] = useState(false);
+  const [linkInput, setLinkInput] = useState('');
+  const [linked, setLinked] = useState<{ id: string; name: string } | null>(null);
+  const [linkError, setLinkError] = useState('');
+
+  const extractFileId = (url: string): string | null => {
+    const match = url.match(/\/d\/([a-zA-Z0-9_-]{25,})/);
+    if (match) return match[1];
+    const match2 = url.match(/id=([a-zA-Z0-9_-]{25,})/);
+    if (match2) return match2[1];
+    if (/^[a-zA-Z0-9_-]{25,}$/.test(url.trim())) return url.trim();
+    return null;
+  };
+
+  const handleConnect = () => {
+    setConnected(true);
+  };
+
+  const handleLinkFile = () => {
+    setLinkError('');
+    const id = extractFileId(linkInput.trim());
+    if (!id) {
+      setLinkError('Paste a Google Drive share link or file ID');
+      return;
+    }
+    const name = `drive_file_${id.slice(0, 8)}`;
+    setLinked({ id, name });
+    onFileLinked?.(id, name);
+  };
+
+  const handleDisconnect = () => {
+    setConnected(false);
+    setLinked(null);
+    setLinkInput('');
+    setLinkError('');
+  };
+
+  return (
+    <section className="gd-section" aria-labelledby="gd-heading">
+      <p className="bu-section-title" id="gd-heading">Google Drive Integration</p>
+
+      <div className="gd-status" role="status" aria-live="polite">
+        <span
+          className={`gd-status-dot${connected ? ' gd-status-dot--connected' : ' gd-status-dot--disconnected'}`}
+          aria-hidden="true"
+        />
+        <span className="gd-status-text">
+          {connected ? 'Connected to Google Drive' : 'Not connected'}
+        </span>
+      </div>
+
+      {!connected ? (
+        <>
+          <button
+            type="button"
+            className="gd-connect-btn"
+            onClick={handleConnect}
+            aria-label="Connect Google Drive account"
+          >
+            <IconDrive />
+            Connect Google Drive
+          </button>
+          <p className="gd-note">
+            Connecting Google Drive allows you to link audio files and cover art directly from your Drive.
+            OAuth authentication is required — you will be redirected to Google to authorize access.
+          </p>
+        </>
+      ) : (
+        <>
+          {linked ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <p className="bu-label">Linked file</p>
+              <div className="gd-status">
+                <IconLink />
+                <span className="gd-status-text" style={{ fontFamily: 'ui-monospace, monospace', fontSize: '0.8rem' }}>
+                  {linked.id}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="bu-reset-btn"
+                onClick={() => { setLinked(null); setLinkInput(''); }}
+                style={{ alignSelf: 'flex-start', marginTop: '0.25rem' }}
+              >
+                Unlink file
+              </button>
+            </div>
+          ) : (
+            <div className="bu-field">
+              <label htmlFor="gd-link-input" className="bu-label">
+                Paste Drive share link or file ID
+              </label>
+              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-start' }}>
+                <input
+                  id="gd-link-input"
+                  type="url"
+                  className={`bu-input${linkError ? ' bu-input--error' : ''}`}
+                  value={linkInput}
+                  onChange={e => setLinkInput(e.target.value)}
+                  onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), handleLinkFile())}
+                  placeholder="https://drive.google.com/file/d/… or file ID"
+                  autoComplete="off"
+                  aria-describedby={linkError ? 'gd-link-err' : undefined}
+                  style={{ flex: 1 }}
+                />
+                <button
+                  type="button"
+                  className="bu-submit-btn"
+                  onClick={handleLinkFile}
+                  style={{ flexShrink: 0 }}
+                >
+                  Link
+                </button>
+              </div>
+              {linkError && (
+                <span id="gd-link-err" className="bu-field-error" role="alert">{linkError}</span>
+              )}
+            </div>
+          )}
+
+          <button
+            type="button"
+            className="bu-reset-btn"
+            onClick={handleDisconnect}
+            style={{ alignSelf: 'flex-start', marginTop: '0.5rem' }}
+          >
+            Disconnect Drive
+          </button>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default GoogleDriveUpload;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,12 +1,259 @@
-import React from 'react';
-import usePageTitle from '../hooks/usePageTitle';
+import React, { useState, useMemo } from 'react';
+import usePageMeta from '../hooks/usePageMeta';
+import '../styles/Admin.css';
+import BeatUpload from '../components/BeatUpload';
+import GoogleDriveUpload from '../components/GoogleDriveUpload';
+import type { Beat } from '../types/beats';
+import beatsData from '../data/beats.json';
+
+const ALL_BEATS: Beat[] = beatsData.beats as Beat[];
+const SESSION_KEY = 'riq_admin_auth';
+const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD ?? 'prodbyriq2025';
+
+/* ── SVG Icons ───────────────────────────────────────────────── */
+const IconLock = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect x="3" y="11" width="18" height="11" rx="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </svg>
+);
+
+const IconSearch = () => (
+  <svg className="bl-search-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+const IconEye = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" /><circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+/* ── Password Gate ───────────────────────────────────────────── */
+const PasswordGate: React.FC<{ onAuth: () => void }> = ({ onAuth }) => {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+    await new Promise(r => setTimeout(r, 300));
+    if (password === ADMIN_PASSWORD) {
+      sessionStorage.setItem(SESSION_KEY, '1');
+      onAuth();
+    } else {
+      setError('Incorrect password. Try again.');
+    }
+    setSubmitting(false);
+  };
+
+  return (
+    <div className="ad-gate" role="main">
+      <div className="ad-gate-card">
+        <span style={{ display: 'flex', justifyContent: 'center', color: 'var(--ad-accent)' }}>
+          <IconLock />
+        </span>
+        <h1 className="ad-gate-heading">Beat Upload Portal</h1>
+        <p className="ad-gate-sub">Admin access only</p>
+        <form onSubmit={handleSubmit} noValidate>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <div className="ad-gate-field">
+              <label htmlFor="ad-password">Password</label>
+              <input
+                id="ad-password"
+                type="password"
+                className="ad-gate-input"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                autoComplete="current-password"
+                aria-required="true"
+                aria-describedby={error ? 'ad-gate-error' : undefined}
+                aria-invalid={!!error}
+              />
+              {error && (
+                <span id="ad-gate-error" className="ad-gate-error" role="alert">{error}</span>
+              )}
+            </div>
+            <button
+              type="submit"
+              className="ad-gate-btn"
+              disabled={submitting || !password}
+              aria-busy={submitting}
+            >
+              {submitting ? 'Checking…' : 'Enter Portal'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+/* ── Beat Library Tab ────────────────────────────────────────── */
+const BeatLibrary: React.FC = () => {
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return ALL_BEATS;
+    const q = search.toLowerCase();
+    return ALL_BEATS.filter(b =>
+      b.title.toLowerCase().includes(q) ||
+      b.beat_id.toLowerCase().includes(q) ||
+      b.genres.some(g => g.toLowerCase().includes(q)) ||
+      b.key.toLowerCase().includes(q)
+    );
+  }, [search]);
+
+  const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0 }).format(n);
+
+  return (
+    <section className="bl-section" aria-label="Beat library">
+      <div className="bl-toolbar">
+        <p className="bl-count">
+          <strong data-stat>{filtered.length}</strong> / {ALL_BEATS.length} beats
+        </p>
+        <div className="bl-search-wrap">
+          <IconSearch />
+          <input
+            type="search"
+            className="bl-search"
+            placeholder="Search by title, ID, genre…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            aria-label="Search beat library"
+          />
+        </div>
+      </div>
+
+      <div className="bl-table-wrap" role="region" aria-label="Beat library table" tabIndex={0}>
+        <table className="bl-table">
+          <thead>
+            <tr>
+              <th scope="col">Title</th>
+              <th scope="col">ID</th>
+              <th scope="col">BPM</th>
+              <th scope="col">Key</th>
+              <th scope="col">Genres</th>
+              <th scope="col">Lease</th>
+              <th scope="col">Excl.</th>
+              <th scope="col">Preview</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="bl-empty">No beats match your search.</td>
+              </tr>
+            ) : (
+              filtered.map(beat => (
+                <tr key={beat.beat_id}>
+                  <td className="bl-title">{beat.title}</td>
+                  <td><span className="bl-beat-id">{beat.beat_id}</span></td>
+                  <td className="bl-bpm">{beat.bpm}</td>
+                  <td>{beat.key}</td>
+                  <td>
+                    {beat.genres.map(g => (
+                      <span key={g} className="bl-genre-pill">{g}</span>
+                    ))}
+                  </td>
+                  <td className="bl-price">{fmt(beat.lease_price)}</td>
+                  <td className="bl-price">{fmt(beat.exclusive_price)}</td>
+                  <td>
+                    {beat.preview_path ? (
+                      <a
+                        href={beat.preview_path}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`Preview ${beat.title}`}
+                        style={{ color: 'var(--ad-text-muted)', display: 'inline-flex' }}
+                      >
+                        <IconEye />
+                      </a>
+                    ) : (
+                      <span style={{ color: 'var(--ad-text-muted)', fontSize: '0.75rem' }}>—</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+/* ── Admin Portal ────────────────────────────────────────────── */
+type Tab = 'upload' | 'library';
 
 const Admin: React.FC = () => {
-  usePageTitle('Admin | PRODBYRIQ');
+  const [authed, setAuthed] = useState(() => sessionStorage.getItem(SESSION_KEY) === '1');
+  const [tab, setTab] = useState<Tab>('upload');
+
+  usePageMeta({
+    title: 'Beat Upload Portal | PRODBYRIQ Admin',
+    description: 'Internal beat management portal for PRODBYRIQ.',
+    canonicalPath: '/admin',
+  });
+
+  const handleLogout = () => {
+    sessionStorage.removeItem(SESSION_KEY);
+    setAuthed(false);
+  };
+
+  if (!authed) {
+    return <div className="ad-page"><PasswordGate onAuth={() => setAuthed(true)} /></div>;
+  }
+
   return (
-    <div style={{ padding: '4rem 2rem', textAlign: 'center' }}>
-      <h1>Beat Upload Portal</h1>
-      <p>Coming soon — beat management portal.</p>
+    <div className="ad-page">
+      {/* Header */}
+      <header className="ad-header">
+        <div className="ad-header-inner">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.1rem' }}>
+            <span className="ad-header-brand">PRODBYRIQ</span>
+            <span className="ad-header-title">Beat Upload Portal</span>
+          </div>
+          <button type="button" className="ad-logout-btn" onClick={handleLogout}>
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      {/* Tabs */}
+      <nav className="ad-tabs-bar" aria-label="Portal sections">
+        <div className="ad-tabs-inner">
+          <button
+            type="button"
+            className={`ad-tab${tab === 'upload' ? ' ad-tab--active' : ''}`}
+            onClick={() => setTab('upload')}
+            aria-current={tab === 'upload' ? 'page' : undefined}
+          >
+            Add Beat
+          </button>
+          <button
+            type="button"
+            className={`ad-tab${tab === 'library' ? ' ad-tab--active' : ''}`}
+            onClick={() => setTab('library')}
+            aria-current={tab === 'library' ? 'page' : undefined}
+          >
+            Beat Library ({ALL_BEATS.length})
+          </button>
+        </div>
+      </nav>
+
+      {/* Main content */}
+      <main className="ad-main" id="main-content">
+        {tab === 'upload' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)' }}>
+            <BeatUpload />
+            <GoogleDriveUpload />
+          </div>
+        )}
+        {tab === 'library' && <BeatLibrary />}
+      </main>
     </div>
   );
 };

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -8,7 +8,7 @@ import beatsData from '../data/beats.json';
 
 const ALL_BEATS: Beat[] = beatsData.beats as Beat[];
 const SESSION_KEY = 'riq_admin_auth';
-const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD ?? 'prodbyriq2025';
+const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD as string | undefined;
 
 /* ── SVG Icons ───────────────────────────────────────────────── */
 const IconLock = () => (
@@ -40,7 +40,9 @@ const PasswordGate: React.FC<{ onAuth: () => void }> = ({ onAuth }) => {
     setError('');
     setSubmitting(true);
     await new Promise(r => setTimeout(r, 300));
-    if (password === ADMIN_PASSWORD) {
+    if (!ADMIN_PASSWORD) {
+      setError('Admin access is not configured. Set VITE_ADMIN_PASSWORD in your environment.');
+    } else if (password === ADMIN_PASSWORD) {
       sessionStorage.setItem(SESSION_KEY, '1');
       onAuth();
     } else {
@@ -196,6 +198,7 @@ const Admin: React.FC = () => {
     title: 'Beat Upload Portal | PRODBYRIQ Admin',
     description: 'Internal beat management portal for PRODBYRIQ.',
     canonicalPath: '/admin',
+    noIndex: true,
   });
 
   const handleLogout = () => {

--- a/src/styles/Admin.css
+++ b/src/styles/Admin.css
@@ -1,0 +1,882 @@
+/* ── Admin / Beat Upload Portal ──────────────────────────────── */
+/* Design system: Minimal Single Column + Dark Mode OLED         */
+/* Skill output: ui-ux-pro-max Phase F                           */
+/* Palette: deep navy surfaces, warm tan accent on dark          */
+
+/* ── Admin-scoped dark tokens ───────────────────────────────── */
+.ad-page {
+  --ad-bg:           #0D1117;
+  --ad-surface:      #161B22;
+  --ad-card:         #21262D;
+  --ad-card-hover:   #2D333B;
+  --ad-border:       rgba(255, 255, 255, 0.08);
+  --ad-border-strong:rgba(255, 255, 255, 0.18);
+  --ad-text-primary: #E6EDF3;
+  --ad-text-secondary:#8B949E;
+  --ad-text-muted:   #6E7681;
+  --ad-accent:       #C8A97E;
+  --ad-accent-hover: #D4B896;
+  --ad-accent-glow:  rgba(200, 169, 126, 0.15);
+  --ad-error:        #F85149;
+  --ad-error-bg:     rgba(248, 81, 73, 0.1);
+  --ad-success:      #3FB950;
+  --ad-success-bg:   rgba(63, 185, 80, 0.1);
+  --ad-focus:        rgba(200, 169, 126, 0.6);
+
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--ad-bg);
+  color: var(--ad-text-primary);
+  font-family: var(--font-body);
+}
+
+/* ── Password Gate ───────────────────────────────────────────── */
+.ad-gate {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  background: var(--ad-bg);
+}
+
+.ad-gate-card {
+  width: 100%;
+  max-width: 380px;
+  background: var(--ad-surface);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-10) var(--space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.ad-gate-heading {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--ad-text-primary);
+  margin: 0;
+  text-align: center;
+  letter-spacing: -0.01em;
+}
+
+.ad-gate-sub {
+  font-size: var(--text-sm);
+  color: var(--ad-text-secondary);
+  text-align: center;
+  margin: -0.75rem 0 0;
+  line-height: 1.55;
+}
+
+.ad-gate-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ad-gate-field label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--ad-text-secondary);
+  letter-spacing: 0.03em;
+}
+
+.ad-gate-input {
+  background: var(--ad-card);
+  border: 1.5px solid var(--ad-border);
+  border-radius: var(--radius-md);
+  padding: 0.7rem 0.875rem;
+  font-size: var(--text-base);
+  color: var(--ad-text-primary);
+  font-family: var(--font-body);
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.ad-gate-input:focus {
+  outline: none;
+  border-color: var(--ad-accent);
+  box-shadow: 0 0 0 3px var(--ad-accent-glow);
+}
+
+.ad-gate-error {
+  font-size: var(--text-xs);
+  color: var(--ad-error);
+  background: var(--ad-error-bg);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
+  role: alert;
+}
+
+.ad-gate-btn {
+  width: 100%;
+  min-height: 44px;
+  background: var(--ad-accent);
+  color: #1a1109;
+  border: 1px solid var(--ad-accent);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  font-weight: 700;
+  font-family: var(--font-body);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: background var(--transition-fast), transform 0.1s var(--ease-spring);
+}
+
+.ad-gate-btn:hover {
+  background: var(--ad-accent-hover);
+  border-color: var(--ad-accent-hover);
+  transform: translateY(-1px);
+}
+
+.ad-gate-btn:active {
+  transform: scale(0.97);
+}
+
+.ad-gate-btn:focus-visible {
+  outline: 2px solid var(--ad-focus);
+  outline-offset: 2px;
+}
+
+/* ── Portal Layout ───────────────────────────────────────────── */
+.ad-header {
+  border-bottom: 1px solid var(--ad-border);
+  background: var(--ad-surface);
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky);
+}
+
+.ad-header-inner {
+  max-width: var(--container-lg);
+  margin-inline: auto;
+  padding: var(--space-4) var(--space-6);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.ad-header-brand {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--ad-accent);
+  letter-spacing: -0.01em;
+}
+
+.ad-header-title {
+  font-size: var(--text-sm);
+  color: var(--ad-text-secondary);
+  font-weight: 500;
+}
+
+.ad-logout-btn {
+  background: transparent;
+  color: var(--ad-text-muted);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.75rem;
+  min-height: 32px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.ad-logout-btn:hover {
+  color: var(--ad-text-primary);
+  border-color: var(--ad-border-strong);
+}
+
+.ad-logout-btn:focus-visible {
+  outline: 2px solid var(--ad-focus);
+  outline-offset: 2px;
+}
+
+/* ── Tabs ────────────────────────────────────────────────────── */
+.ad-tabs-bar {
+  border-bottom: 1px solid var(--ad-border);
+  background: var(--ad-surface);
+}
+
+.ad-tabs-inner {
+  max-width: var(--container-lg);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
+  display: flex;
+  gap: 0;
+}
+
+.ad-tab {
+  background: transparent;
+  color: var(--ad-text-muted);
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  margin-bottom: -1px;
+}
+
+.ad-tab:hover {
+  color: var(--ad-text-secondary);
+}
+
+.ad-tab--active {
+  color: var(--ad-accent);
+  border-bottom-color: var(--ad-accent);
+}
+
+.ad-tab:focus-visible {
+  outline: 2px solid var(--ad-focus);
+  outline-offset: -2px;
+}
+
+/* ── Main content ────────────────────────────────────────────── */
+.ad-main {
+  max-width: var(--container-lg);
+  margin-inline: auto;
+  padding: var(--space-8) var(--space-6);
+}
+
+/* ── Beat Upload Form ────────────────────────────────────────── */
+.bu-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: 680px;
+}
+
+.bu-section {
+  background: var(--ad-surface);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.bu-section-title {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ad-text-muted);
+  margin: 0;
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--ad-border);
+}
+
+.bu-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+}
+
+.bu-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.bu-field--full {
+  grid-column: 1 / -1;
+}
+
+.bu-label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--ad-text-secondary);
+}
+
+.bu-label-required::after {
+  content: ' *';
+  color: var(--ad-error);
+}
+
+.bu-input,
+.bu-select {
+  background: var(--ad-card);
+  border: 1.5px solid var(--ad-border);
+  border-radius: var(--radius-md);
+  padding: 0.65rem 0.875rem;
+  font-size: var(--text-base);
+  color: var(--ad-text-primary);
+  font-family: var(--font-body);
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.bu-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238B949E' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.875rem center;
+  padding-right: 2.5rem;
+  cursor: pointer;
+}
+
+.bu-input:focus,
+.bu-select:focus {
+  outline: none;
+  border-color: var(--ad-accent);
+  box-shadow: 0 0 0 3px var(--ad-accent-glow);
+}
+
+.bu-input--error,
+.bu-select--error {
+  border-color: var(--ad-error);
+}
+
+.bu-input--error:focus,
+.bu-select--error:focus {
+  box-shadow: 0 0 0 3px var(--ad-error-bg);
+}
+
+.bu-field-error {
+  font-size: var(--text-xs);
+  color: var(--ad-error);
+}
+
+.bu-helper {
+  font-size: var(--text-xs);
+  color: var(--ad-text-muted);
+  line-height: 1.5;
+}
+
+/* Checkbox group */
+.bu-checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.bu-checkbox-pill {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  min-height: 32px;
+  background: var(--ad-card);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  color: var(--ad-text-secondary);
+  cursor: pointer;
+  touch-action: manipulation;
+  user-select: none;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.bu-checkbox-pill input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.bu-checkbox-pill--checked {
+  background: var(--ad-accent-glow);
+  border-color: var(--ad-accent);
+  color: var(--ad-accent);
+  font-weight: 600;
+}
+
+.bu-checkbox-pill:hover {
+  border-color: var(--ad-border-strong);
+  color: var(--ad-text-primary);
+}
+
+/* Tags input */
+.bu-tags-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  background: var(--ad-card);
+  border: 1.5px solid var(--ad-border);
+  border-radius: var(--radius-md);
+  padding: 0.5rem;
+  min-height: 44px;
+  cursor: text;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.bu-tags-wrap:focus-within {
+  border-color: var(--ad-accent);
+  box-shadow: 0 0 0 3px var(--ad-accent-glow);
+}
+
+.bu-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: var(--ad-accent-glow);
+  border: 1px solid var(--ad-accent);
+  color: var(--ad-accent);
+  border-radius: var(--radius-full);
+  padding: 0.15rem 0.5rem 0.15rem 0.65rem;
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.bu-tag-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ad-accent);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  line-height: 1;
+  font-size: 1rem;
+  opacity: 0.7;
+  transition: opacity var(--transition-fast);
+}
+
+.bu-tag-remove:hover { opacity: 1; }
+
+.bu-tag-input {
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: var(--text-sm);
+  color: var(--ad-text-primary);
+  font-family: var(--font-body);
+  min-width: 100px;
+  flex: 1;
+  padding: 0.15rem 0.25rem;
+}
+
+/* Submit row */
+.bu-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.bu-submit-btn {
+  min-height: 44px;
+  padding: 0.75rem 2rem;
+  background: var(--ad-accent);
+  color: #1a1109;
+  border: 1px solid var(--ad-accent);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  font-weight: 700;
+  font-family: var(--font-body);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: background var(--transition-fast), transform 0.1s var(--ease-spring);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.bu-submit-btn:hover:not(:disabled) {
+  background: var(--ad-accent-hover);
+  border-color: var(--ad-accent-hover);
+  transform: translateY(-1px);
+}
+
+.bu-submit-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.bu-submit-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bu-submit-btn:focus-visible {
+  outline: 2px solid var(--ad-focus);
+  outline-offset: 2px;
+}
+
+.bu-reset-btn {
+  min-height: 44px;
+  padding: 0.75rem 1.25rem;
+  background: transparent;
+  color: var(--ad-text-secondary);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.bu-reset-btn:hover {
+  color: var(--ad-text-primary);
+  border-color: var(--ad-border-strong);
+}
+
+.bu-reset-btn:focus-visible {
+  outline: 2px solid var(--ad-focus);
+  outline-offset: 2px;
+}
+
+/* Success toast */
+.bu-success-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  background: var(--ad-success-bg);
+  border: 1px solid var(--ad-success);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  animation: buFadeIn 0.2s var(--ease-out);
+}
+
+.bu-success-icon {
+  color: var(--ad-success);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.bu-success-text {
+  font-size: var(--text-sm);
+  color: var(--ad-text-primary);
+  line-height: 1.5;
+}
+
+.bu-success-text strong {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.bu-json-block {
+  background: var(--ad-card);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--ad-text-secondary);
+  white-space: pre;
+  overflow-x: auto;
+  max-height: 200px;
+  margin-top: var(--space-3);
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, monospace;
+  line-height: 1.6;
+}
+
+.bu-copy-btn {
+  margin-top: var(--space-2);
+  min-height: 36px;
+  padding: 0.4rem 0.875rem;
+  background: var(--ad-card);
+  color: var(--ad-text-secondary);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.bu-copy-btn:hover {
+  color: var(--ad-text-primary);
+  border-color: var(--ad-border-strong);
+}
+
+.bu-copy-btn--copied {
+  color: var(--ad-success);
+  border-color: var(--ad-success);
+}
+
+.bu-copy-btn:focus-visible {
+  outline: 2px solid var(--ad-focus);
+  outline-offset: 2px;
+}
+
+@keyframes buFadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Beat Library Table ──────────────────────────────────────── */
+.bl-section {
+  background: var(--ad-surface);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.bl-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--ad-border);
+  flex-wrap: wrap;
+}
+
+.bl-count {
+  font-size: var(--text-sm);
+  color: var(--ad-text-muted);
+  font-weight: 500;
+}
+
+.bl-count strong {
+  color: var(--ad-text-primary);
+  font-feature-settings: "tnum" 1;
+}
+
+.bl-search-wrap {
+  position: relative;
+  flex: 1;
+  max-width: 260px;
+}
+
+.bl-search-icon {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ad-text-muted);
+  pointer-events: none;
+}
+
+.bl-search {
+  background: var(--ad-card);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-md);
+  padding: 0.45rem 0.75rem 0.45rem 2.25rem;
+  font-size: var(--text-sm);
+  color: var(--ad-text-primary);
+  font-family: var(--font-body);
+  width: 100%;
+  min-height: 36px;
+  box-sizing: border-box;
+  transition: border-color 0.18s ease;
+}
+
+.bl-search:focus {
+  outline: none;
+  border-color: var(--ad-accent);
+}
+
+.bl-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.bl-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.bl-table th {
+  text-align: left;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ad-text-muted);
+  border-bottom: 1px solid var(--ad-border);
+  white-space: nowrap;
+}
+
+.bl-table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--ad-border);
+  color: var(--ad-text-secondary);
+  vertical-align: middle;
+}
+
+.bl-table tr:last-child td {
+  border-bottom: none;
+}
+
+.bl-table tbody tr:hover td {
+  background: var(--ad-card-hover);
+  color: var(--ad-text-primary);
+}
+
+.bl-title {
+  font-weight: 600;
+  color: var(--ad-text-primary);
+}
+
+.bl-beat-id {
+  font-family: ui-monospace, monospace;
+  font-size: var(--text-xs);
+  color: var(--ad-text-muted);
+}
+
+.bl-bpm {
+  font-feature-settings: "tnum" 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.bl-genre-pill {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: var(--ad-card);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  color: var(--ad-text-muted);
+  margin: 0.1rem;
+}
+
+.bl-price {
+  font-feature-settings: "tnum" 1;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--ad-accent);
+}
+
+.bl-empty {
+  text-align: center;
+  padding: var(--space-12) var(--space-6);
+  color: var(--ad-text-muted);
+  font-size: var(--text-sm);
+}
+
+/* ── Google Drive section ────────────────────────────────────── */
+.gd-section {
+  background: var(--ad-surface);
+  border: 1px solid var(--ad-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.gd-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--ad-card);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--ad-border);
+}
+
+.gd-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.gd-status-dot--connected { background: var(--ad-success); }
+.gd-status-dot--disconnected { background: var(--ad-text-muted); }
+
+.gd-status-text {
+  font-size: var(--text-sm);
+  color: var(--ad-text-secondary);
+}
+
+.gd-connect-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding: 0.7rem 1.5rem;
+  background: var(--ad-card);
+  color: var(--ad-text-primary);
+  border: 1.5px solid var(--ad-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  font-family: var(--font-body);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  align-self: flex-start;
+}
+
+.gd-connect-btn:hover {
+  background: var(--ad-card-hover);
+  border-color: var(--ad-accent);
+  color: var(--ad-accent);
+}
+
+.gd-connect-btn:focus-visible {
+  outline: 2px solid var(--ad-focus);
+  outline-offset: 2px;
+}
+
+.gd-note {
+  font-size: var(--text-xs);
+  color: var(--ad-text-muted);
+  line-height: 1.6;
+  padding: var(--space-3) var(--space-4);
+  background: var(--ad-card);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--ad-border-strong);
+}
+
+/* ── Responsive ──────────────────────────────────────────────── */
+@media (max-width: 1024px) {
+  .ad-main {
+    padding-inline: var(--space-5);
+  }
+}
+
+@media (max-width: 768px) {
+  .ad-header-inner {
+    padding-inline: var(--space-4);
+  }
+
+  .ad-tabs-inner {
+    padding-inline: var(--space-4);
+  }
+
+  .ad-main {
+    padding: var(--space-6) var(--space-4);
+  }
+
+  .bu-row {
+    grid-template-columns: 1fr;
+  }
+
+  .bl-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .bl-search-wrap {
+    max-width: 100%;
+    width: 100%;
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ad-page * {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/styles/Admin.css
+++ b/src/styles/Admin.css
@@ -111,7 +111,6 @@
   background: var(--ad-error-bg);
   border-radius: var(--radius-sm);
   padding: 0.4rem 0.6rem;
-  role: alert;
 }
 
 .ad-gate-btn {
@@ -387,9 +386,22 @@
 
 .bu-checkbox-pill input[type="checkbox"] {
   position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
   opacity: 0;
-  width: 0;
-  height: 0;
+}
+
+.bu-checkbox-pill:focus-within {
+  border-color: var(--ad-accent);
+  box-shadow: 0 0 0 3px var(--ad-focus);
+  color: var(--ad-text-primary);
 }
 
 .bu-checkbox-pill--checked {


### PR DESCRIPTION
## Summary

- Full Admin page rewrite: password-gated portal with tab navigation (Add Beat / Beat Library)
- `BeatUpload.tsx`: complete beat entry form with inline blur validation, JSON generation, and clipboard copy
- `GoogleDriveUpload.tsx`: Drive connection status UI and share link → file ID extractor
- `Admin.css`: dark admin token system scoped to `.ad-page`, fully separate from public site warm neutrals

## Design system (ui-ux-pro-max Phase F output)
- **Pattern:** Minimal Single Column
- **Style:** Dark Mode OLED — `#0D1117` base, warm tan (`#C8A97E`) accent on dark
- **UX rules applied:** inline blur validation, aria-required/aria-describedby, role="alert" errors, touch-action: manipulation, 44px min touch targets, progress feedback (submitting state), prefers-reduced-motion scoped to `.ad-page *`

## Test plan

- [ ] `/admin` route shows password gate (correct password: env var `VITE_ADMIN_PASSWORD`)
- [ ] Wrong password shows error; correct password unlocks portal
- [ ] Sign out clears session and returns to gate
- [ ] Add Beat form: required fields validate on blur, errors clear on fix
- [ ] Generate JSON Entry produces valid JSON matching `beats.json` schema
- [ ] Copy to clipboard button shows "Copied!" confirmation
- [ ] Beat Library tab shows all 16 beats; search filters by title, ID, genre, key
- [ ] Preview link opens S3 URL in new tab
- [ ] Google Drive: connect/disconnect toggles status; link extractor parses Drive URLs and file IDs
- [ ] Responsive at 375px and 768px — no horizontal scroll
- [ ] Dark admin theme is fully isolated from public site warm neutral palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)