### PR TITLE
fix(env): defensive guard for Stripe key + trigger rebuild with VITE vars

### DIFF
--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -1,7 +1,9 @@
 import { loadStripe } from '@stripe/stripe-js';
 import type { CartItem } from '../types/beats';
 
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY);
+const stripeKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY as string | undefined;
+if (!stripeKey) throw new Error('VITE_STRIPE_PUBLISHABLE_KEY is not configured');
+const stripePromise = loadStripe(stripeKey);
 
 export interface CheckoutData {
   items: CartItem[];


### PR DESCRIPTION
## Summary
- Adds a guard in `stripe.ts` that throws a clear error if `VITE_STRIPE_PUBLISHABLE_KEY` is undefined at build time, instead of crashing Stripe.js internally with a cryptic `match` TypeError
- This PR also serves as the trigger for a fresh Railway source build — both `VITE_STRIPE_PUBLISHABLE_KEY` and `VITE_ADMIN_PASSWORD` are now set in Railway env vars and will be baked into the bundle correctly on this rebuild

## Root Cause
Vite bakes `VITE_*` variables at build time. Both vars were added to Railway *after* the last build ran, so the bundle contained `undefined` for both. A Railway "Redeploy" reruns the cached build image — it does not rebuild from source. Merging this PR triggers a fresh source build with both vars present.

## Test plan
- [ ] After merge and Railway deploy completes, visit `/admin` — password gate should appear (not "Admin access is not configured")
- [ ] Enter password — should grant access
- [ ] Add a beat to cart and click Checkout — should redirect to Stripe without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)