### PR TITLE
fix(stripe): remove unused loadStripe that white-screened the site

### DIFF
--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -1,9 +1,4 @@
-import { loadStripe } from '@stripe/stripe-js';
 import type { CartItem } from '../types/beats';
-
-const stripeKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY as string | undefined;
-if (!stripeKey) throw new Error('VITE_STRIPE_PUBLISHABLE_KEY is not configured');
-const stripePromise = loadStripe(stripeKey);
 
 export interface CheckoutData {
   items: CartItem[];
@@ -29,7 +24,7 @@ export const createCheckoutSession = async (checkoutData: CheckoutData): Promise
     }
 
     const data = await response.json();
-    
+
     if (data.url) {
       return data.url;
     } else {
@@ -50,5 +45,3 @@ export const redirectToCheckout = async (checkoutData: CheckoutData): Promise<vo
     throw error;
   }
 };
-
-export { stripePromise };


### PR DESCRIPTION
## Summary
- Removes `loadStripe`, `stripePromise`, and the `@stripe/stripe-js` import from `stripe.ts`
- The checkout flow uses the backend to create a session and redirects via `window.location.href` — Stripe.js is never used client-side
- The module-scope guard added in PR #36 threw at app startup (because `CartDrawer` imports this module and is always mounted in `App`), causing a white-screen whenever `VITE_STRIPE_PUBLISHABLE_KEY` was undefined in the bundle

## Root Cause of White-Screen
```
// PR #36 added this at module scope — throws on import, crashing the whole app
if (!stripeKey) throw new Error('...');
```
`CartDrawer` → `stripe.ts` is in the critical render path. Any throw here = white screen.

## Test plan
- [ ] Site loads without white-screen in production
- [ ] Add a beat to cart → Checkout → redirects to Stripe hosted checkout
- [ ] No Stripe-related console errors on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)