### PR TITLE
fix(admin): move password auth to backend — never expose in JS bundle

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import { timingSafeEqual } from 'crypto';
 import Stripe from 'stripe';
 import { rateLimit } from 'express-rate-limit';
 
@@ -189,6 +190,38 @@ const formRateLimit = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },
+});
+
+const adminAuthLimit = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many login attempts, please try again later.' },
+});
+
+// Admin password auth — password stays server-side only
+app.post('/admin/auth', adminAuthLimit, (req, res) => {
+  const adminPassword = process.env.ADMIN_PASSWORD;
+  if (!adminPassword) {
+    return res.status(503).json({ error: 'Admin access is not configured on the server.' });
+  }
+  const { password } = req.body;
+  if (typeof password !== 'string' || password.length === 0) {
+    return res.status(400).json({ error: 'Password is required.' });
+  }
+  try {
+    const expected = Buffer.from(adminPassword, 'utf8');
+    const provided = Buffer.from(password, 'utf8');
+    const match = expected.length === provided.length &&
+      timingSafeEqual(expected, provided);
+    if (match) {
+      return res.json({ success: true });
+    }
+    return res.status(401).json({ error: 'Incorrect password. Try again.' });
+  } catch {
+    return res.status(401).json({ error: 'Incorrect password. Try again.' });
+  }
 });
 
 // Inquiry form submission

--- a/server.js
+++ b/server.js
@@ -55,6 +55,7 @@ function toAbsoluteUrl(imagePath, baseUrl) {
   return /^https?:\/\//.test(imagePath) ? imagePath : `${baseUrl}${imagePath}`;
 }
 
+app.set('trust proxy', 1);
 app.use(express.json());
 
 // Serve static files from the dist directory

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -8,7 +8,6 @@ import beatsData from '../data/beats.json';
 
 const ALL_BEATS: Beat[] = beatsData.beats as Beat[];
 const SESSION_KEY = 'riq_admin_auth';
-const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD as string | undefined;
 
 /* ── SVG Icons ───────────────────────────────────────────────── */
 const IconLock = () => (
@@ -39,14 +38,21 @@ const PasswordGate: React.FC<{ onAuth: () => void }> = ({ onAuth }) => {
     e.preventDefault();
     setError('');
     setSubmitting(true);
-    await new Promise(r => setTimeout(r, 300));
-    if (!ADMIN_PASSWORD) {
-      setError('Admin access is not configured. Set VITE_ADMIN_PASSWORD in your environment.');
-    } else if (password === ADMIN_PASSWORD) {
-      sessionStorage.setItem(SESSION_KEY, '1');
-      onAuth();
-    } else {
-      setError('Incorrect password. Try again.');
+    try {
+      const res = await fetch('/admin/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      if (res.ok) {
+        sessionStorage.setItem(SESSION_KEY, '1');
+        onAuth();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? 'Incorrect password. Try again.');
+      }
+    } catch {
+      setError('Unable to reach server. Try again.');
     }
     setSubmitting(false);
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     proxy: {
       '/submit-inquiry': 'http://localhost:4000',
       '/subscribe': 'http://localhost:4000',
+      '/admin/auth': 'http://localhost:4000',
     },
   },
   preview: {


### PR DESCRIPTION
## Summary
- Removes `VITE_ADMIN_PASSWORD` from `Admin.tsx` — password no longer baked into the client bundle
- Adds `POST /admin/auth` endpoint to `server.js` — validates against `ADMIN_PASSWORD` env var using `timingSafeEqual` (prevents timing attacks), rate-limited to 10 attempts per 15 minutes
- Frontend POSTs the entered password to `/admin/auth`, stores a `sessionStorage` flag on success — the actual password never touches the client

## Railway env var change required
- **Add** `ADMIN_PASSWORD` = your password (server-side only)
- **Delete** `VITE_ADMIN_PASSWORD` (no longer needed)

## Test plan
- [ ] Enter correct password on `/admin` — should grant access
- [ ] Enter wrong password — should show "Incorrect password. Try again."
- [ ] Inspect the built JS bundle — password should not appear anywhere
- [ ] Refreshing the page should re-prompt for password (sessionStorage cleared on tab close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)