### PR TITLE
fix(admin): scope .ad-tab to .ad-page to fix global button style override

### DIFF
--- a/src/styles/Admin.css
+++ b/src/styles/Admin.css
@@ -215,12 +215,15 @@
   gap: 0;
 }
 
-.ad-tab {
+.ad-page .ad-tab {
   background: transparent;
+  background-color: transparent;
   color: var(--ad-text-muted);
   border: none;
   border-bottom: 2px solid transparent;
+  box-shadow: none;
   padding: var(--space-3) var(--space-5);
+  min-height: unset;
   font-size: var(--text-sm);
   font-weight: 600;
   font-family: var(--font-body);
@@ -228,18 +231,24 @@
   touch-action: manipulation;
   transition: color var(--transition-fast), border-color var(--transition-fast);
   margin-bottom: -1px;
+  transform: none;
 }
 
-.ad-tab:hover {
+.ad-page .ad-tab:hover {
+  background: transparent;
+  background-color: transparent;
   color: var(--ad-text-secondary);
+  border-color: transparent;
+  transform: none;
+  box-shadow: none;
 }
 
-.ad-tab--active {
+.ad-page .ad-tab--active {
   color: var(--ad-accent);
   border-bottom-color: var(--ad-accent);
 }
 
-.ad-tab:focus-visible {
+.ad-page .ad-tab:focus-visible {
   outline: 2px solid var(--ad-focus);
   outline-offset: -2px;
 }


### PR DESCRIPTION
## Summary
- Admin tabs appeared as solid dark brown blocks because the global `button` tag rule in `index.css` sets `background-color: var(--accent-primary)` and `border: 1px solid var(--accent-primary)` — a class selector (`.ad-tab`) has equal specificity to a tag selector (`button`), so the global rule was winning
- Fixed by scoping all tab rules to `.ad-page .ad-tab` which gives the class chain higher specificity than the bare `button` tag rule

## Test plan
- [ ] Admin tabs appear as transparent text-only tabs on the dark background, not filled brown blocks
- [ ] Inactive tab text is muted gray (`#6E7681`)
- [ ] Active tab text is warm gold (`#C8A97E`) with bottom border accent
- [ ] Hover state doesn't show the global button hover transform/shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)